### PR TITLE
feat: Flywayマイグレーションによるスキーマ作成

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jdbc")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
-    implementation("org.flywaydb:flyway-core")
+    implementation("org.springframework.boot:spring-boot-starter-flyway")
     implementation("org.flywaydb:flyway-database-postgresql")
     runtimeOnly("org.postgresql:postgresql")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6")

--- a/backend/src/main/resources/db/migration/V1__create_users.sql
+++ b/backend/src/main/resources/db/migration/V1__create_users.sql
@@ -1,0 +1,10 @@
+CREATE TABLE users (
+    id            BIGINT       GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    google_id     VARCHAR(255) NOT NULL,
+    email         VARCHAR(255) NOT NULL,
+    display_name  VARCHAR(100) NOT NULL,
+    currency_code CHAR(3)      NOT NULL,
+    created_at    TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT uk_users_google_id UNIQUE (google_id)
+);

--- a/backend/src/main/resources/db/migration/V2__create_categories.sql
+++ b/backend/src/main/resources/db/migration/V2__create_categories.sql
@@ -1,0 +1,7 @@
+CREATE TABLE categories (
+    id            BIGINT      GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name          VARCHAR(50) NOT NULL,
+    display_order INTEGER     NOT NULL,
+
+    CONSTRAINT uk_categories_name UNIQUE (name)
+);

--- a/backend/src/main/resources/db/migration/V3__create_transactions.sql
+++ b/backend/src/main/resources/db/migration/V3__create_transactions.sql
@@ -1,0 +1,27 @@
+CREATE TABLE transactions (
+    id             BIGINT        GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    user_id        BIGINT        NOT NULL,
+    date           DATE          NOT NULL,
+    amount         DECIMAL(12,4) NOT NULL,
+    category_id    BIGINT        NOT NULL,
+    need_want_type VARCHAR(5)    NOT NULL DEFAULT 'UNSET',
+    title          VARCHAR(200),
+    memo           TEXT,
+    created_at     TIMESTAMPTZ   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at     TIMESTAMPTZ   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT fk_transactions_user_id
+        FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE,
+    CONSTRAINT fk_transactions_category_id
+        FOREIGN KEY (category_id) REFERENCES categories (id) ON DELETE RESTRICT,
+    CONSTRAINT ck_transactions_amount_positive
+        CHECK (amount > 0),
+    CONSTRAINT ck_transactions_need_want_type
+        CHECK (need_want_type IN ('NEED', 'WANT', 'UNSET'))
+);
+
+CREATE INDEX idx_transactions_user_id_date
+    ON transactions (user_id, date DESC);
+
+CREATE INDEX idx_transactions_user_id_date_category
+    ON transactions (user_id, date DESC, category_id);

--- a/backend/src/main/resources/db/migration/V4__insert_preset_categories.sql
+++ b/backend/src/main/resources/db/migration/V4__insert_preset_categories.sql
@@ -1,0 +1,12 @@
+INSERT INTO categories (name, display_order) VALUES
+    ('Food',           1),
+    ('Transport',      2),
+    ('Housing',        3),
+    ('Daily Goods',    4),
+    ('Medical',        5),
+    ('Entertainment',  6),
+    ('Clothing',       7),
+    ('Education',      8),
+    ('Social',         9),
+    ('Other',         10),
+    ('Uncategorized', 11);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
     volumes:
-      - db-data:/var/lib/postgresql/data
+      - db-data:/var/lib/postgresql
 
   mock-server:
     image: stoplight/prism:4


### PR DESCRIPTION
## Summary
- database-schema.mdに基づき、Flywayマイグレーションファイル4本（users, categories, transactions, プリセットカテゴリ）を追加
- Spring Boot 4対応: `flyway-core` → `spring-boot-starter-flyway` に変更（Spring Boot 4ではFlywayの自動構成が別モジュールに分離されたため）
- PostgreSQL 18対応: docker-composeのボリュームマウントパスを `/var/lib/postgresql/data` → `/var/lib/postgresql` に修正

## Test plan
- [x] `docker compose up` でDBが正常起動すること
- [x] `./gradlew bootRun` でFlywayマイグレーションが正常実行されること
- [x] users, categories, transactionsテーブルが作成されること
- [x] プリセットカテゴリ11件が登録されること

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
