### PR TITLE
feat: LocaleCurrencyMapperに言語コードのみのLocaleから通貨を推定するマッピングを追加

### DIFF
--- a/backend/src/main/java/com/youmorry/expensetracker/domain/model/user/LocaleCurrencyMapper.java
+++ b/backend/src/main/java/com/youmorry/expensetracker/domain/model/user/LocaleCurrencyMapper.java
@@ -33,8 +33,8 @@ public final class LocaleCurrencyMapper {
   /**
    * 指定された {@link Locale} を ISO 4217 通貨コードに変換する。
    *
-   * <p>{@link Currency#getInstance(Locale)} を使用して JDK の locale-通貨マッピングで解決する。
-   * 国コードを持たない Locale の場合、言語コードから代表国コードを推定して解決を試みる。 解決できない場合は USD を返す。
+   * <p>{@link Currency#getInstance(Locale)} を使用して JDK の locale-通貨マッピングで解決する。 国コードを持たない Locale
+   * の場合、言語コードから代表国コードを推定して解決を試みる。 解決できない場合は USD を返す。
    *
    * @param locale ロケール（例: {@code Locale.of("ja", "JP")}）。null 可
    * @return 推定された通貨コード

--- a/backend/src/test/java/com/youmorry/expensetracker/domain/model/user/LocaleCurrencyMapperTest.java
+++ b/backend/src/test/java/com/youmorry/expensetracker/domain/model/user/LocaleCurrencyMapperTest.java
@@ -49,18 +49,8 @@ class LocaleCurrencyMapperTest {
 
   @ParameterizedTest
   @CsvSource({
-    "ja, JPY",
-    "ko, KRW",
-    "zh, CNY",
-    "hi, INR",
-    "th, THB",
-    "vi, VND",
-    "tr, TRY",
-    "ru, RUB",
-    "pl, PLN",
-    "sv, SEK",
-    "da, DKK",
-    "nb, NOK"
+    "ja, JPY", "ko, KRW", "zh, CNY", "hi, INR", "th, THB", "vi, VND", "tr, TRY", "ru, RUB",
+    "pl, PLN", "sv, SEK", "da, DKK", "nb, NOK"
   })
   void toCurrencyCode_withMappedLanguageOnlyLocale_returnsEstimatedCurrency(
       String languageTag, String expected) {


### PR DESCRIPTION
## 概要

`LocaleCurrencyMapper` に言語コード → 代表国コードの静的マッピングを追加し、言語コードのみの Locale（例: `ja`, `ko`）でも通貨を推定できるようにする。

## 変更内容

- 「1言語 = 1つの代表的な通貨」が明確な12言語（ja, ko, zh, hi, th, vi, tr, ru, pl, sv, da, nb）のマッピングテーブルを追加
- 国コードを持たない Locale の場合、マッピングテーブルから代表国コードを取得して通貨を解決
- マッピングに存在しない言語（fr, es, pt, ar 等の複数国で使われる言語）は従来通り USD にフォールバック
- マッピング対象12言語のパラメータ化テストと、マッピング外言語の USD フォールバックテストを追加

## 関連 Issue

Closes #66

## テスト

- `LocaleCurrencyMapperTest` の全テストが通過することを確認済み
  - マッピング対象12言語が正しい通貨コードを返すこと
  - マッピング外の言語（fr, es, pt, ar, de, it, nl, en）が USD を返すこと
  - 既存テスト（国コード付き Locale, null, 不明な国コード）が引き続き通過すること

---
🤖 Generated with [Claude Code](https://claude.ai/code)