### PR TITLE
refactor: UserResponseをpresentation/user/パッケージに移動

### DIFF
--- a/backend/src/main/java/com/youmorry/expensetracker/presentation/auth/AuthResponse.java
+++ b/backend/src/main/java/com/youmorry/expensetracker/presentation/auth/AuthResponse.java
@@ -1,6 +1,7 @@
 package com.youmorry.expensetracker.presentation.auth;
 
 import com.youmorry.expensetracker.application.AuthService.AuthResult;
+import com.youmorry.expensetracker.presentation.user.UserResponse;
 
 /** Google 認証レスポンス。JWT アクセストークンとユーザー情報を返す。 */
 public record AuthResponse(String accessToken, UserResponse user) {

--- a/backend/src/main/java/com/youmorry/expensetracker/presentation/user/UserController.java
+++ b/backend/src/main/java/com/youmorry/expensetracker/presentation/user/UserController.java
@@ -2,7 +2,6 @@ package com.youmorry.expensetracker.presentation.user;
 
 import com.youmorry.expensetracker.application.UserService;
 import com.youmorry.expensetracker.domain.model.user.UserId;
-import com.youmorry.expensetracker.presentation.auth.UserResponse;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;

--- a/backend/src/main/java/com/youmorry/expensetracker/presentation/user/UserResponse.java
+++ b/backend/src/main/java/com/youmorry/expensetracker/presentation/user/UserResponse.java
@@ -1,4 +1,4 @@
-package com.youmorry.expensetracker.presentation.auth;
+package com.youmorry.expensetracker.presentation.user;
 
 import com.youmorry.expensetracker.domain.model.user.User;
 import java.time.Instant;


### PR DESCRIPTION
## 概要

`UserResponse` はユーザー情報の共通レスポンス DTO であり、`presentation/auth/` パッケージに配置されているのは不自然なため、`presentation/user/` パッケージに移動する。

## 変更内容

- `UserResponse` を `presentation/auth/` → `presentation/user/` に移動
- `AuthResponse` に新しいパッケージの import を追加
- `UserController` から不要になった import を削除

## 関連 Issue

Closes #56

## テスト

- `./gradlew test` 全テスト通過確認済み

---
🤖 Generated with [Claude Code](https://claude.ai/code)