### PR TITLE
test: UserControllerTestのupdateCurrencyテストにverify()を追加

### DIFF
--- a/backend/src/test/java/com/youmorry/expensetracker/presentation/user/UserControllerTest.java
+++ b/backend/src/test/java/com/youmorry/expensetracker/presentation/user/UserControllerTest.java
@@ -1,5 +1,8 @@
 package com.youmorry.expensetracker.presentation.user;
 
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
@@ -110,6 +113,8 @@ class UserControllerTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.id").value(1))
         .andExpect(jsonPath("$.currency_code").value("USD"));
+
+    verify(userService).updateCurrency(userId, "USD");
   }
 
   @Test
@@ -129,6 +134,8 @@ class UserControllerTest {
         .andExpect(status().is(422))
         .andExpect(jsonPath("$.type").value("/errors/validation-error"))
         .andExpect(jsonPath("$.errors[0].pointer").value("#/currency_code"));
+
+    verify(userService).updateCurrency(new UserId(1L), "INVALID");
   }
 
   @Test
@@ -140,6 +147,8 @@ class UserControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{}"))
         .andExpect(status().is(422));
+
+    verify(userService, never()).updateCurrency(eq(new UserId(1L)), anyString());
   }
 
   // --- DELETE /api/v1/users/me ---


### PR DESCRIPTION
## 概要

`UserControllerTest` の `updateCurrency` 関連テストに `verify()` を追加し、サービスメソッドの呼び出しを明示的に検証するようにした。

## 変更内容

- `updateCurrency_withValidRequest`: `verify(userService).updateCurrency(userId, "USD")` を追加
- `updateCurrency_withInvalidCurrencyCode`: `verify(userService).updateCurrency(...)` を追加
- `updateCurrency_withMissingCurrencyCode`: `verify(userService, never()).updateCurrency(...)` を追加し、サービスが呼ばれないことを検証

## 関連 Issue

Closes #59

## テスト

- `./gradlew test --tests "com.youmorry.expensetracker.presentation.user.UserControllerTest"` で全テスト Green を確認
- `./gradlew build` でビルド・Checkstyle・Spotless すべて成功を確認

---
🤖 Generated with [Claude Code](https://claude.ai/code)