### PR TITLE
docs: リポジトリ統合テストのアノテーションを @DataJdbcTest に変更

### DIFF
--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -127,7 +127,7 @@ public ResponseEntity<TransactionResponse> create(
 |----------|-----------|----------------------|-----|
 | domain | 純粋な単体テスト | なし（Plain JUnit） | 不要 |
 | application | 単体テスト | Mockito でリポジトリをモック | 不要 |
-| infrastructure | 統合テスト | `@SpringBootTest` + Testcontainers | PostgreSQL |
+| infrastructure | 統合テスト | `@DataJdbcTest` + Testcontainers + Flyway | PostgreSQL |
 | presentation | スライステスト | `@WebMvcTest` + MockMvc | 不要 |
 
 - H2 は使わない。統合テストでは必ず Testcontainers（PostgreSQL）を使用する


### PR DESCRIPTION
## 概要
リポジトリ統合テストのテスト戦略を `@SpringBootTest` から `@DataJdbcTest` に変更する。

## 変更内容
- `.claude/rules/backend.md` のレイヤー別テスト戦略表で、infrastructure 層のアノテーションを `@SpringBootTest` + Testcontainers から `@DataJdbcTest` + Testcontainers + Flyway に更新
- リポジトリは Spring Data JDBC のインターフェースであり、フルコンテキストではなくスライステストが適切なため

## 関連 Issue
Closes #83

## テスト
- ドキュメントのみの変更のため、テスト不要

---
🤖 Generated with [Claude Code](https://claude.ai/code)