### PR TITLE
feat: Spring Data JDBC の ID 型カスタムコンバーターを追加

### DIFF
--- a/backend/src/main/java/com/youmorry/expensetracker/infrastructure/persistence/JdbcConfiguration.java
+++ b/backend/src/main/java/com/youmorry/expensetracker/infrastructure/persistence/JdbcConfiguration.java
@@ -1,5 +1,6 @@
 package com.youmorry.expensetracker.infrastructure.persistence;
 
+import com.youmorry.expensetracker.infrastructure.persistence.converter.IdConverters;
 import java.util.List;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jdbc.repository.config.AbstractJdbcConfiguration;

--- a/backend/src/main/java/com/youmorry/expensetracker/infrastructure/persistence/converter/IdConverters.java
+++ b/backend/src/main/java/com/youmorry/expensetracker/infrastructure/persistence/converter/IdConverters.java
@@ -1,4 +1,4 @@
-package com.youmorry.expensetracker.infrastructure.persistence;
+package com.youmorry.expensetracker.infrastructure.persistence.converter;
 
 import com.youmorry.expensetracker.domain.model.category.CategoryId;
 import com.youmorry.expensetracker.domain.model.transaction.TransactionId;
@@ -12,12 +12,12 @@ import org.springframework.data.convert.WritingConverter;
  *
  * <p>{@code Long ↔ CategoryId}, {@code Long ↔ UserId}, {@code Long ↔ TransactionId} の変換を提供する。
  */
-final class IdConverters {
+public final class IdConverters {
 
   private IdConverters() {}
 
   @ReadingConverter
-  enum LongToCategoryId implements Converter<Long, CategoryId> {
+  public enum LongToCategoryId implements Converter<Long, CategoryId> {
     INSTANCE;
 
     @Override
@@ -27,7 +27,7 @@ final class IdConverters {
   }
 
   @WritingConverter
-  enum CategoryIdToLong implements Converter<CategoryId, Long> {
+  public enum CategoryIdToLong implements Converter<CategoryId, Long> {
     INSTANCE;
 
     @Override
@@ -37,7 +37,7 @@ final class IdConverters {
   }
 
   @ReadingConverter
-  enum LongToUserId implements Converter<Long, UserId> {
+  public enum LongToUserId implements Converter<Long, UserId> {
     INSTANCE;
 
     @Override
@@ -47,7 +47,7 @@ final class IdConverters {
   }
 
   @WritingConverter
-  enum UserIdToLong implements Converter<UserId, Long> {
+  public enum UserIdToLong implements Converter<UserId, Long> {
     INSTANCE;
 
     @Override
@@ -57,7 +57,7 @@ final class IdConverters {
   }
 
   @ReadingConverter
-  enum LongToTransactionId implements Converter<Long, TransactionId> {
+  public enum LongToTransactionId implements Converter<Long, TransactionId> {
     INSTANCE;
 
     @Override
@@ -67,7 +67,7 @@ final class IdConverters {
   }
 
   @WritingConverter
-  enum TransactionIdToLong implements Converter<TransactionId, Long> {
+  public enum TransactionIdToLong implements Converter<TransactionId, Long> {
     INSTANCE;
 
     @Override


### PR DESCRIPTION
## 概要
Spring Data JDBC が ID 型（`CategoryId`, `UserId`, `TransactionId`）を DB カラム値（`Long`）から変換できるよう、カスタムコンバーターを実装する。

## 変更内容
- `IdConverters` — `Long ↔ CategoryId / UserId / TransactionId` の `ReadingConverter`・`WritingConverter`（6個）
- `JdbcConfiguration` — `AbstractJdbcConfiguration` を継承し、`userConverters()` でコンバーターを登録

## 関連 Issue
Closes #89

## テスト
- `./gradlew build` が成功することを確認済み
- コンバーターは #84（Testcontainers 統合テスト基盤）のリポジトリテストで間接的に検証される

---
🤖 Generated with [Claude Code](https://claude.ai/code)