### PR TITLE
refactor: infrastructure/persistence/ を infrastructure/repository/ に統合

### DIFF
--- a/backend/src/main/java/com/youmorry/expensetracker/infrastructure/repository/JdbcConfiguration.java
+++ b/backend/src/main/java/com/youmorry/expensetracker/infrastructure/repository/JdbcConfiguration.java
@@ -1,7 +1,7 @@
-package com.youmorry.expensetracker.infrastructure.persistence;
+package com.youmorry.expensetracker.infrastructure.repository;
 
-import com.youmorry.expensetracker.infrastructure.persistence.converter.IdConverters;
-import com.youmorry.expensetracker.infrastructure.persistence.converter.ValueObjectConverters;
+import com.youmorry.expensetracker.infrastructure.repository.converter.IdConverters;
+import com.youmorry.expensetracker.infrastructure.repository.converter.ValueObjectConverters;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.List;

--- a/backend/src/main/java/com/youmorry/expensetracker/infrastructure/repository/converter/IdConverters.java
+++ b/backend/src/main/java/com/youmorry/expensetracker/infrastructure/repository/converter/IdConverters.java
@@ -1,4 +1,4 @@
-package com.youmorry.expensetracker.infrastructure.persistence.converter;
+package com.youmorry.expensetracker.infrastructure.repository.converter;
 
 import com.youmorry.expensetracker.domain.category.CategoryId;
 import com.youmorry.expensetracker.domain.transaction.TransactionId;

--- a/backend/src/main/java/com/youmorry/expensetracker/infrastructure/repository/converter/ValueObjectConverters.java
+++ b/backend/src/main/java/com/youmorry/expensetracker/infrastructure/repository/converter/ValueObjectConverters.java
@@ -1,4 +1,4 @@
-package com.youmorry.expensetracker.infrastructure.persistence.converter;
+package com.youmorry.expensetracker.infrastructure.repository.converter;
 
 import com.youmorry.expensetracker.domain.transaction.Money;
 import com.youmorry.expensetracker.domain.user.CurrencyCode;


### PR DESCRIPTION
## 概要

`infrastructure/` 配下に並立していた `persistence/` と `repository/` パッケージを `repository/` に統合し、Spring Data JDBC 関連の実装を一箇所に集約した。

## 変更内容

- `infrastructure/persistence/JdbcConfiguration.java` → `infrastructure/repository/JdbcConfiguration.java` に移動
- `infrastructure/persistence/converter/IdConverters.java` → `infrastructure/repository/converter/IdConverters.java` に移動
- `infrastructure/persistence/converter/ValueObjectConverters.java` → `infrastructure/repository/converter/ValueObjectConverters.java` に移動
- 各ファイルのパッケージ宣言・import を更新
- 空の `persistence/` ディレクトリを削除

## 関連 Issue

Closes #105

## テスト

- `./gradlew build` が成功することを確認済み（コンパイル・全テスト・Checkstyle・Spotless）

---
🤖 Generated with [Claude Code](https://claude.ai/code)