### PR TITLE
docs: ドメイン層の compact constructor に @throws Javadoc を追加

### DIFF
--- a/backend/src/main/java/com/youmorry/expensetracker/domain/category/Category.java
+++ b/backend/src/main/java/com/youmorry/expensetracker/domain/category/Category.java
@@ -10,7 +10,12 @@ public record Category(@Id CategoryId id, String name, int displayOrder) {
 
   private static final int NAME_MAX_LENGTH = 50;
 
-  /** 不変条件を検証する。 */
+  /**
+   * 不変条件を検証する。
+   *
+   * @throws NullPointerException name が null の場合
+   * @throws IllegalArgumentException name が空白、50 文字超過、または displayOrder が 0 以下の場合
+   */
   public Category {
     Objects.requireNonNull(name, "name must not be null");
     if (name.isBlank()) {

--- a/backend/src/main/java/com/youmorry/expensetracker/domain/category/CategoryId.java
+++ b/backend/src/main/java/com/youmorry/expensetracker/domain/category/CategoryId.java
@@ -1,12 +1,16 @@
 package com.youmorry.expensetracker.domain.category;
 
 /**
- * Value Object: Category ID
+ * Value Object: Category ID.
  *
  * @param value Category ID
  */
 public record CategoryId(long value) {
-  /** constructor */
+  /**
+   * ID が正の値であることを検証する。
+   *
+   * @throws IllegalArgumentException value が 0 以下の場合
+   */
   public CategoryId {
     if (value <= 0) {
       throw new IllegalArgumentException("CategoryId value must be positive, but was: " + value);

--- a/backend/src/main/java/com/youmorry/expensetracker/domain/transaction/Money.java
+++ b/backend/src/main/java/com/youmorry/expensetracker/domain/transaction/Money.java
@@ -6,7 +6,12 @@ import java.util.Objects;
 /** 金額を表す値オブジェクト。0 より大きい正の値のみ許容する。 */
 public record Money(BigDecimal value) {
 
-  /** 金額が正の値であることを検証する。 */
+  /**
+   * 金額が正の値であることを検証する。
+   *
+   * @throws NullPointerException value が null の場合
+   * @throws IllegalArgumentException value が 0 以下の場合
+   */
   public Money {
     Objects.requireNonNull(value, "value must not be null");
     if (value.compareTo(BigDecimal.ZERO) <= 0) {

--- a/backend/src/main/java/com/youmorry/expensetracker/domain/transaction/Transaction.java
+++ b/backend/src/main/java/com/youmorry/expensetracker/domain/transaction/Transaction.java
@@ -28,7 +28,12 @@ public record Transaction(
 
   private static final int TITLE_MAX_LENGTH = 200;
 
-  /** 不変条件を検証する。 */
+  /**
+   * 不変条件を検証する。
+   *
+   * @throws NullPointerException userId, date, amount, categoryId, needWantType が null の場合
+   * @throws IllegalArgumentException title が 200 文字を超過する場合
+   */
   public Transaction {
     Objects.requireNonNull(userId, "userId must not be null");
     Objects.requireNonNull(date, "date must not be null");

--- a/backend/src/main/java/com/youmorry/expensetracker/domain/transaction/TransactionId.java
+++ b/backend/src/main/java/com/youmorry/expensetracker/domain/transaction/TransactionId.java
@@ -1,12 +1,16 @@
 package com.youmorry.expensetracker.domain.transaction;
 
 /**
- * Value Object: Transaction ID
+ * Value Object: Transaction ID.
  *
  * @param value Transaction ID
  */
 public record TransactionId(long value) {
-  /** constructor */
+  /**
+   * ID が正の値であることを検証する。
+   *
+   * @throws IllegalArgumentException value が 0 以下の場合
+   */
   public TransactionId {
     if (value <= 0) {
       throw new IllegalArgumentException("TransactionId value must be positive, but was: " + value);

--- a/backend/src/main/java/com/youmorry/expensetracker/domain/user/CurrencyCode.java
+++ b/backend/src/main/java/com/youmorry/expensetracker/domain/user/CurrencyCode.java
@@ -28,7 +28,12 @@ public record CurrencyCode(String value) {
   public static final CurrencyCode DKK = new CurrencyCode("DKK");
   public static final CurrencyCode NOK = new CurrencyCode("NOK");
 
-  /** 通貨コードが ISO 4217 に準拠していることを検証する。 */
+  /**
+   * 通貨コードが ISO 4217 に準拠していることを検証する。
+   *
+   * @throws NullPointerException value が null の場合
+   * @throws IllegalArgumentException value が空白、または ISO 4217 に準拠しない場合
+   */
   public CurrencyCode {
     Objects.requireNonNull(value, "Currency code must not be null");
     if (value.isBlank()) {

--- a/backend/src/main/java/com/youmorry/expensetracker/domain/user/User.java
+++ b/backend/src/main/java/com/youmorry/expensetracker/domain/user/User.java
@@ -24,7 +24,12 @@ public record User(
 
   private static final int DISPLAY_NAME_MAX_LENGTH = 100;
 
-  /** 不変条件を検証する。 */
+  /**
+   * 不変条件を検証する。
+   *
+   * @throws NullPointerException googleId, email, displayName, currencyCode が null の場合
+   * @throws IllegalArgumentException googleId, email, displayName が空白、または displayName が 100 文字超過の場合
+   */
   public User {
     Objects.requireNonNull(googleId, "googleId must not be null");
     if (googleId.isBlank()) {

--- a/backend/src/main/java/com/youmorry/expensetracker/domain/user/UserId.java
+++ b/backend/src/main/java/com/youmorry/expensetracker/domain/user/UserId.java
@@ -3,6 +3,11 @@ package com.youmorry.expensetracker.domain.user;
 /** ユーザーの識別子。 */
 public record UserId(long value) {
 
+  /**
+   * ID が正の値であることを検証する。
+   *
+   * @throws IllegalArgumentException value が 0 以下の場合
+   */
   public UserId {
     if (value <= 0) {
       throw new IllegalArgumentException("UserId value must be positive, but was: " + value);


### PR DESCRIPTION
## 概要

ドメイン層の compact constructor で例外をスローしているが `@throws` Javadoc が未記載だったため、全対象に追加する。

## 変更内容

- `CurrencyCode`, `Money` の compact constructor に `@throws` Javadoc を追加
- `CategoryId`, `Category`, `TransactionId`, `Transaction`, `UserId`, `User` にも同様に追加
- `CategoryId`, `TransactionId`, `UserId` の既存 Javadoc を Checkstyle SummaryJavadoc に適合するよう修正

## 関連 Issue

Closes #64

## テスト

- `./gradlew build` でビルド成功を確認済み
- Javadoc のみの変更のため、既存テストへの影響なし

---
🤖 Generated with [Claude Code](https://claude.ai/code)