### PR TITLE
docs: ドメイン層の Javadoc に @param, @return, @throws を追記

### DIFF
--- a/backend/src/main/java/com/youmorry/expensetracker/domain/category/Category.java
+++ b/backend/src/main/java/com/youmorry/expensetracker/domain/category/Category.java
@@ -4,7 +4,13 @@ import java.util.Objects;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Table;
 
-/** 支出を分類するカテゴリのエンティティ。 */
+/**
+ * 支出を分類するカテゴリのエンティティ。
+ *
+ * @param id カテゴリ ID
+ * @param name カテゴリ名
+ * @param displayOrder 表示順
+ */
 @Table("categories")
 public record Category(@Id CategoryId id, String name, int displayOrder) {
 

--- a/backend/src/main/java/com/youmorry/expensetracker/domain/category/CategoryRepository.java
+++ b/backend/src/main/java/com/youmorry/expensetracker/domain/category/CategoryRepository.java
@@ -6,9 +6,18 @@ import java.util.Optional;
 /** カテゴリの永続化を担うリポジトリインターフェース。 */
 public interface CategoryRepository {
 
-  /** 指定された ID のカテゴリを取得する。 */
+  /**
+   * 指定された ID のカテゴリを取得する。
+   *
+   * @param id カテゴリ ID
+   * @return カテゴリ。存在しない場合は空
+   */
   Optional<Category> findById(CategoryId id);
 
-  /** カテゴリを全件取得する。 */
+  /**
+   * カテゴリを全件取得する。
+   *
+   * @return カテゴリのリスト
+   */
   List<Category> findAll();
 }

--- a/backend/src/main/java/com/youmorry/expensetracker/domain/transaction/Money.java
+++ b/backend/src/main/java/com/youmorry/expensetracker/domain/transaction/Money.java
@@ -3,7 +3,11 @@ package com.youmorry.expensetracker.domain.transaction;
 import java.math.BigDecimal;
 import java.util.Objects;
 
-/** 金額を表す値オブジェクト。0 より大きい正の値のみ許容する。 */
+/**
+ * 金額を表す値オブジェクト。0 より大きい正の値のみ許容する。
+ *
+ * @param value 金額
+ */
 public record Money(BigDecimal value) {
 
   /**

--- a/backend/src/main/java/com/youmorry/expensetracker/domain/transaction/Transaction.java
+++ b/backend/src/main/java/com/youmorry/expensetracker/domain/transaction/Transaction.java
@@ -12,7 +12,20 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
 
-/** ユーザーが記録する1件の支出を表すエンティティ。 */
+/**
+ * ユーザーが記録する1件の支出を表すエンティティ。
+ *
+ * @param id 支出記録 ID（永続化時に採番）
+ * @param userId 記録したユーザーの ID
+ * @param date 支出日
+ * @param amount 金額
+ * @param categoryId カテゴリ ID
+ * @param needWantType 必要/欲しい 区分
+ * @param title タイトル
+ * @param memo メモ
+ * @param createdAt 作成日時（永続化時に設定）
+ * @param updatedAt 更新日時（永続化時に設定）
+ */
 @Table("transactions")
 public record Transaction(
     @Id @Nullable TransactionId id,

--- a/backend/src/main/java/com/youmorry/expensetracker/domain/transaction/TransactionRepository.java
+++ b/backend/src/main/java/com/youmorry/expensetracker/domain/transaction/TransactionRepository.java
@@ -7,15 +7,34 @@ import java.util.Optional;
 /** 支出記録の永続化を担うリポジトリインターフェース。 */
 public interface TransactionRepository {
 
-  /** 指定された ID の支出記録を取得する。 */
+  /**
+   * 指定された ID の支出記録を取得する。
+   *
+   * @param id 支出記録 ID
+   * @return 支出記録。存在しない場合は空
+   */
   Optional<Transaction> findById(TransactionId id);
 
-  /** 指定されたユーザーの支出記録を全件取得する。 */
+  /**
+   * 指定されたユーザーの支出記録を全件取得する。
+   *
+   * @param userId ユーザー ID
+   * @return 支出記録のリスト
+   */
   List<Transaction> findByUserId(UserId userId);
 
-  /** 支出記録を保存する。 */
+  /**
+   * 支出記録を保存する。
+   *
+   * @param transaction 保存する支出記録
+   * @return 保存された支出記録（ID 採番済み）
+   */
   Transaction save(Transaction transaction);
 
-  /** 指定された ID の支出記録を削除する。 */
+  /**
+   * 指定された ID の支出記録を削除する。
+   *
+   * @param id 削除する支出記録の ID
+   */
   void deleteById(TransactionId id);
 }

--- a/backend/src/main/java/com/youmorry/expensetracker/domain/user/CurrencyCode.java
+++ b/backend/src/main/java/com/youmorry/expensetracker/domain/user/CurrencyCode.java
@@ -3,7 +3,11 @@ package com.youmorry.expensetracker.domain.user;
 import java.util.Currency;
 import java.util.Objects;
 
-/** ISO 4217 通貨コードを表す値オブジェクト。 */
+/**
+ * ISO 4217 通貨コードを表す値オブジェクト。
+ *
+ * @param value ISO 4217 通貨コード（例: "JPY", "USD"）
+ */
 public record CurrencyCode(String value) {
 
   public static final CurrencyCode JPY = new CurrencyCode("JPY");

--- a/backend/src/main/java/com/youmorry/expensetracker/domain/user/User.java
+++ b/backend/src/main/java/com/youmorry/expensetracker/domain/user/User.java
@@ -12,6 +12,13 @@ import org.springframework.data.relational.core.mapping.Table;
  *
  * <p>現在は Google OAuth2 のみをサポートしているため {@code googleId} を直接保持しているが、 複数の認証プロバイダをサポートする場合は {@code
  * LinkedAccount} 等の別エンティティに分離すること。
+ *
+ * @param id ユーザー ID（永続化時に採番）
+ * @param googleId Google ユーザーの一意識別子
+ * @param email メールアドレス
+ * @param displayName 表示名
+ * @param currencyCode 通貨コード
+ * @param createdAt 作成日時（永続化時に設定）
  */
 @Table("users")
 public record User(
@@ -72,6 +79,7 @@ public record User(
    *
    * @param newCurrencyCode 通貨コード
    * @return 通貨コードが更新されたユーザー
+   * @throws NullPointerException newCurrencyCode が null の場合
    */
   public User changeCurrencyCode(CurrencyCode newCurrencyCode) {
     Objects.requireNonNull(newCurrencyCode, "Currency code must not be null");

--- a/backend/src/main/java/com/youmorry/expensetracker/domain/user/UserId.java
+++ b/backend/src/main/java/com/youmorry/expensetracker/domain/user/UserId.java
@@ -1,6 +1,10 @@
 package com.youmorry.expensetracker.domain.user;
 
-/** ユーザーの識別子。 */
+/**
+ * ユーザーの識別子。
+ *
+ * @param value ユーザー ID
+ */
 public record UserId(long value) {
 
   /**


### PR DESCRIPTION
## 概要
ドメイン層のクラスに不足していた `@param`、`@return`、`@throws` Javadoc タグを追記する。

## 変更内容
- Record クラス（Transaction, Money, User, UserId, CurrencyCode, Category）にクラスレベルの `@param` タグを追加
- リポジトリインターフェース（TransactionRepository, CategoryRepository）のメソッドに `@param` / `@return` タグを追加
- `User#changeCurrencyCode()` に `@throws NullPointerException` タグを追加

## 関連 Issue
Closes #116

## テスト
- `./gradlew build` でビルド成功を確認済み
- Javadoc のみの変更のため、既存テストへの影響なし

---
🤖 Generated with [Claude Code](https://claude.ai/code)