### PR TITLE
docs: ドキュメントと実装の乖離を修正

### DIFF
--- a/docs/03-design/api-design.md
+++ b/docs/03-design/api-design.md
@@ -482,7 +482,7 @@ GET /api/v1/analytics/category
 | categories[].transaction_count | number | 該当する支出の件数 |
 
 **ルール**
-- 金額 0 のカテゴリは含めない（screen-flow.md の仕様に準拠）
+- 金額 0 のカテゴリも含む（全カテゴリを返す）
 - categories は amount の降順でソート
 - percentage の合計は丸め誤差により 100.0 と一致しない場合がある
 

--- a/docs/03-design/database-schema.md
+++ b/docs/03-design/database-schema.md
@@ -148,7 +148,8 @@ backend/src/main/resources/db/migration/
 ├── V1__create_users.sql
 ├── V2__create_categories.sql
 ├── V3__create_transactions.sql
-└── V4__insert_preset_categories.sql
+├── V4__insert_preset_categories.sql
+└── V5__drop_amount_positive_check.sql
 ```
 
 ### V1__create_users.sql


### PR DESCRIPTION
## 概要

ドキュメントと実装の間に見つかった2箇所の乖離を修正する。いずれも実装が正しいため、ドキュメント側を実装に合わせる。

## 変更内容

- `docs/03-design/api-design.md`: `GET /api/v1/analytics/category` の0件カテゴリに関するルールを「含めない」から「全カテゴリを返す」に修正
- `docs/03-design/database-schema.md`: Flywayマイグレーション一覧に `V5__drop_amount_positive_check.sql` を追記

## 関連 Issue

Closes #151

## テスト

- ドキュメントのみの変更のため、ビルド・テストへの影響なし

---
🤖 Generated with [Claude Code](https://claude.ai/code)