### PR TITLE
chore(deps): Dependabot設定と自動マージワークフローを追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,74 @@
+version: 2
+
+updates:
+  # Gradle (backend)
+  - package-ecosystem: gradle
+    directory: /backend
+    schedule:
+      interval: weekly
+      day: monday
+      timezone: Asia/Tokyo
+    labels:
+      - dependencies
+      - backend
+    open-pull-requests-limit: 5
+    groups:
+      spring-boot:
+        patterns:
+          - "org.springframework*"
+      testcontainers:
+        patterns:
+          - "org.testcontainers*"
+      google:
+        patterns:
+          - "com.google*"
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+        exclude-patterns:
+          - "org.springframework*"
+          - "org.testcontainers*"
+          - "com.google*"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
+
+  # Docker
+  - package-ecosystem: docker-compose
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      timezone: Asia/Tokyo
+    labels:
+      - dependencies
+    open-pull-requests-limit: 3
+    groups:
+      all:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
+
+  # GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      timezone: Asia/Tokyo
+    labels:
+      - dependencies
+    open-pull-requests-limit: 3
+    groups:
+      all:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,26 @@
+name: Dependabot Auto Merge
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto-merge minor and patch updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 概要

依存関係の自動更新とセキュリティパッチの検知のため、Dependabotを導入する。
ノイズ最小限の設計で、minor/patchは自動マージ、メジャーは手動対応とする。

## 変更内容

- `.github/dependabot.yml` を新規作成
  - Gradle / Docker / GitHub Actions の3エコシステムを対象に週次チェック（月曜・JST）
  - Gradle: Spring Boot / Testcontainers / Google のグルーピング + 残りのminor/patchを1PRにまとめ
  - Docker / GitHub Actions: 各エコシステム全依存を1グループに
  - メジャーアップデートは全エコシステムで除外
- `.github/workflows/dependabot-auto-merge.yml` を新規作成
  - Dependabot PRのminor/patchをCI通過後に自動squashマージ
- GitHub上に `dependencies` ラベルを作成

## 関連 Issue

Closes #111

## テスト

- mainマージ後にDependabotが自動で初回スキャンを実行し、PRが作成されることを確認
- 作成されたPRのグルーピング・ラベルが想定通りか確認
- 自動マージワークフローがDependabot PRで正常に動作するか確認

---
🤖 Generated with [Claude Code](https://claude.ai/code)