### PR TITLE
feat(test): Auth・Transaction統合テスト（Phase 1）

### DIFF
--- a/backend/src/integrationTest/java/com/youmorry/expensetracker/integration/AbstractIntegrationTest.java
+++ b/backend/src/integrationTest/java/com/youmorry/expensetracker/integration/AbstractIntegrationTest.java
@@ -4,6 +4,10 @@ import com.youmorry.expensetracker.application.auth.JwtTokenGenerator;
 import com.youmorry.expensetracker.application.auth.OauthTokenVerifier;
 import com.youmorry.expensetracker.domain.user.UserId;
 import com.youmorry.expensetracker.testutil.SharedPostgresContainer;
+import java.math.BigDecimal;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -43,5 +47,32 @@ abstract class AbstractIntegrationTest {
 
   protected String generateToken(UserId userId, String email) {
     return "Bearer " + jwtTokenGenerator.generateToken(userId, email);
+  }
+
+  protected UserId insertUser(String googleId, String email, String displayName) {
+    jdbcTemplate.update(
+        "INSERT INTO users (google_id, email, display_name) VALUES (?, ?, ?)",
+        googleId,
+        email,
+        displayName);
+    var id =
+        jdbcTemplate.queryForObject(
+            "SELECT id FROM users WHERE google_id = ?", Long.class, googleId);
+    return new UserId(id);
+  }
+
+  /** スケール（小数桁数）を無視して金額を数値比較する Hamcrest マッチャー。 */
+  protected static Matcher<String> amountEqualTo(String expected) {
+    return new TypeSafeMatcher<>() {
+      @Override
+      protected boolean matchesSafely(String actual) {
+        return new BigDecimal(actual).compareTo(new BigDecimal(expected)) == 0;
+      }
+
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("amount numerically equal to ").appendValue(expected);
+      }
+    };
   }
 }

--- a/backend/src/integrationTest/java/com/youmorry/expensetracker/integration/AuthIntegrationTest.java
+++ b/backend/src/integrationTest/java/com/youmorry/expensetracker/integration/AuthIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.youmorry.expensetracker.integration;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
@@ -53,26 +54,22 @@ class AuthIntegrationTest extends AbstractIntegrationTest {
         .andExpect(jsonPath("$.user.id").isNumber());
 
     // 2回目: 同じユーザーで再認証 → 新規作成されない
-    String secondResponse =
-        mockMvc
-            .perform(
-                post("/api/v1/auth/google")
-                    .contentType(APPLICATION_JSON)
-                    .content(
-                        """
-                        {"id_token": "valid-google-token"}
-                        """))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.user.email").value("existing@example.com"))
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
+    mockMvc
+        .perform(
+            post("/api/v1/auth/google")
+                .contentType(APPLICATION_JSON)
+                .content(
+                    """
+                    {"id_token": "valid-google-token"}
+                    """))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.user.email").value("existing@example.com"));
 
     // users テーブルに同一 google_id のレコードが1件のみであることを確認
     var count =
         jdbcTemplate.queryForObject(
             "SELECT COUNT(*) FROM users WHERE google_id = ?", Integer.class, "google-sub-456");
-    assert count == 1 : "Expected 1 user but found " + count;
+    assertThat(count).isEqualTo(1);
   }
 
   @Test

--- a/backend/src/integrationTest/java/com/youmorry/expensetracker/integration/TransactionIntegrationTest.java
+++ b/backend/src/integrationTest/java/com/youmorry/expensetracker/integration/TransactionIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.youmorry.expensetracker.integration;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -10,7 +11,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.jayway.jsonpath.JsonPath;
-import com.youmorry.expensetracker.domain.user.UserId;
 import org.junit.jupiter.api.Test;
 
 /** コア CRUD（Transaction）の一気通貫テスト。 */
@@ -39,7 +39,7 @@ class TransactionIntegrationTest extends AbstractIntegrationTest {
         .andExpect(status().isCreated())
         .andExpect(jsonPath("$.id", notNullValue()))
         .andExpect(jsonPath("$.date").value("2026-03-15"))
-        .andExpect(jsonPath("$.amount").value("1500"))
+        .andExpect(jsonPath("$.amount", amountEqualTo("1500")))
         .andExpect(jsonPath("$.category_id").value(1))
         .andExpect(jsonPath("$.category_name").value("Food"))
         .andExpect(jsonPath("$.need_want_type").value("NEED"))
@@ -49,7 +49,7 @@ class TransactionIntegrationTest extends AbstractIntegrationTest {
     var count =
         jdbcTemplate.queryForObject(
             "SELECT COUNT(*) FROM transactions WHERE user_id = ?", Integer.class, userId.value());
-    assert count == 1 : "Expected 1 transaction but found " + count;
+    assertThat(count).isEqualTo(1);
   }
 
   @Test
@@ -116,7 +116,7 @@ class TransactionIntegrationTest extends AbstractIntegrationTest {
                     """))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.date").value("2026-03-20"))
-        .andExpect(jsonPath("$.amount").value("2000"))
+        .andExpect(jsonPath("$.amount", amountEqualTo("2000")))
         .andExpect(jsonPath("$.title").value("Updated"));
   }
 
@@ -150,7 +150,7 @@ class TransactionIntegrationTest extends AbstractIntegrationTest {
     var count =
         jdbcTemplate.queryForObject(
             "SELECT COUNT(*) FROM transactions WHERE id = ?", Integer.class, transactionId);
-    assert count == 0 : "Expected 0 transactions but found " + count;
+    assertThat(count).isZero();
   }
 
   @Test
@@ -187,7 +187,7 @@ class TransactionIntegrationTest extends AbstractIntegrationTest {
     mockMvc
         .perform(get("/api/v1/transactions/" + transactionId).header("Authorization", token))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.amount").value("3000.0000"))
+        .andExpect(jsonPath("$.amount", amountEqualTo("3000")))
         .andExpect(jsonPath("$.category_name").value("Entertainment"))
         .andExpect(jsonPath("$.need_want_type").value("WANT"))
         .andExpect(jsonPath("$.title").value("Movie ticket"))
@@ -210,7 +210,7 @@ class TransactionIntegrationTest extends AbstractIntegrationTest {
                     }
                     """))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.amount").value("3500"))
+        .andExpect(jsonPath("$.amount", amountEqualTo("3500")))
         .andExpect(jsonPath("$.title").value("Movie ticket + popcorn"));
 
     // Delete
@@ -222,17 +222,5 @@ class TransactionIntegrationTest extends AbstractIntegrationTest {
     mockMvc
         .perform(get("/api/v1/transactions/" + transactionId).header("Authorization", token))
         .andExpect(status().isNotFound());
-  }
-
-  private UserId insertUser(String googleId, String email, String displayName) {
-    jdbcTemplate.update(
-        "INSERT INTO users (google_id, email, display_name) VALUES (?, ?, ?)",
-        googleId,
-        email,
-        displayName);
-    var id =
-        jdbcTemplate.queryForObject(
-            "SELECT id FROM users WHERE google_id = ?", Long.class, googleId);
-    return new UserId(id);
   }
 }


### PR DESCRIPTION
## 概要
Issue #161 Phase 1 として、認証フローと Transaction CRUD の統合テストを追加する。
フルリクエストライフサイクル（HTTP → Security → Controller → Service → Repository → DB → レスポンス）を検証する。

## 変更内容
- `AuthIntegrationTest` を追加（3テスト）
  - 正常な Google 認証 → JWT 発行 + ユーザー作成
  - 既存ユーザーの再認証 → 重複作成されないことを検証
  - 無効トークン → 401 レスポンス（RFC 9457）
- `TransactionIntegrationTest` を追加（5テスト）
  - 有効な JWT での Transaction 作成 → 201 + DB 永続化
  - 他ユーザーの Transaction 取得 → 404（存在秘匿）
  - Transaction 更新 → 200 + DB 反映
  - Transaction 削除 → 204 + DB 削除
  - CRUD ライフサイクル（Create → Read → Update → Delete → 404）
- `AbstractIntegrationTest` の `jdbcTemplate` を `protected` に変更（サブクラスからの DB 検証用）

## 関連 Issue
Ref #161

## テスト
- `./gradlew integrationTest` — 全11テスト通過
- `./gradlew check` — UT + IT + Checkstyle + Spotless 全パス

---
🤖 Generated with [Claude Code](https://claude.ai/code)