### PR TITLE
feat(test): Search・Analytics統合テスト（Phase 3）

### DIFF
--- a/backend/src/integrationTest/java/com/youmorry/expensetracker/integration/AbstractIntegrationTest.java
+++ b/backend/src/integrationTest/java/com/youmorry/expensetracker/integration/AbstractIntegrationTest.java
@@ -1,5 +1,9 @@
 package com.youmorry.expensetracker.integration;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.youmorry.expensetracker.application.auth.JwtTokenGenerator;
 import com.youmorry.expensetracker.application.auth.OauthTokenVerifier;
 import com.youmorry.expensetracker.domain.user.UserId;
@@ -92,6 +96,43 @@ abstract class AbstractIntegrationTest {
             .expiresAt(now.minus(1, ChronoUnit.HOURS))
             .build();
     return "Bearer " + encoder.encode(JwtEncoderParameters.from(header, claims)).getTokenValue();
+  }
+
+  /** テスト用の取引を作成するヘルパー。 */
+  protected void createTransaction(
+      String token,
+      String date,
+      String amount,
+      int categoryId,
+      String needWantType,
+      String title,
+      String memo)
+      throws Exception {
+    var memoField = memo != null ? ", \"memo\": \"" + memo + "\"" : "";
+    mockMvc
+        .perform(
+            post("/api/v1/transactions")
+                .header("Authorization", token)
+                .contentType(APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "date": "%s",
+                      "amount": "%s",
+                      "category_id": %d,
+                      "need_want_type": "%s",
+                      "title": "%s"%s
+                    }
+                    """
+                        .formatted(date, amount, categoryId, needWantType, title, memoField)))
+        .andExpect(status().isCreated());
+  }
+
+  /** memo なしの取引作成ヘルパー。 */
+  protected void createTransaction(
+      String token, String date, String amount, int categoryId, String needWantType, String title)
+      throws Exception {
+    createTransaction(token, date, amount, categoryId, needWantType, title, null);
   }
 
   /** スケール（小数桁数）を無視して金額を数値比較する Hamcrest マッチャー。 */

--- a/backend/src/integrationTest/java/com/youmorry/expensetracker/integration/AnalyticsIntegrationTest.java
+++ b/backend/src/integrationTest/java/com/youmorry/expensetracker/integration/AnalyticsIntegrationTest.java
@@ -2,9 +2,7 @@ package com.youmorry.expensetracker.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.hasSize;
-import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -12,6 +10,7 @@ import com.jayway.jsonpath.JsonPath;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 /** 分析エンドポイント（カテゴリ別集計・need/want 比率）の一気通貫テスト。 */
@@ -141,34 +140,11 @@ class AnalyticsIntegrationTest extends AbstractIntegrationTest {
         .andExpect(jsonPath("$.total_amount", amountEqualTo("1000")));
   }
 
-  private void createTransaction(
-      String token, String date, String amount, int categoryId, String needWantType, String title)
-      throws Exception {
-    mockMvc
-        .perform(
-            post("/api/v1/transactions")
-                .header("Authorization", token)
-                .contentType(APPLICATION_JSON)
-                .content(
-                    """
-                    {
-                      "date": "%s",
-                      "amount": "%s",
-                      "category_id": %d,
-                      "need_want_type": "%s",
-                      "title": "%s"
-                    }
-                    """
-                        .formatted(date, amount, categoryId, needWantType, title)))
-        .andExpect(status().isCreated());
-  }
-
   /** Breakdown 配列を type をキーとする Map に変換する。 */
   private Map<String, Map<String, Object>> parseBreakdown(String json) {
     List<Map<String, Object>> items = JsonPath.read(json, "$.breakdown");
     return items.stream()
-        .collect(
-            java.util.stream.Collectors.toMap(item -> (String) item.get("type"), item -> item));
+        .collect(Collectors.toMap(item -> (String) item.get("type"), item -> item));
   }
 
   private void assertNeedWantItem(

--- a/backend/src/integrationTest/java/com/youmorry/expensetracker/integration/TransactionSearchIntegrationTest.java
+++ b/backend/src/integrationTest/java/com/youmorry/expensetracker/integration/TransactionSearchIntegrationTest.java
@@ -1,9 +1,7 @@
 package com.youmorry.expensetracker.integration;
 
 import static org.hamcrest.Matchers.hasSize;
-import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -167,34 +165,5 @@ class TransactionSearchIntegrationTest extends AbstractIntegrationTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.items", hasSize(1)))
         .andExpect(jsonPath("$.items[0].title").value("User1 tx"));
-  }
-
-  private void createTransaction(
-      String token,
-      String date,
-      String amount,
-      int categoryId,
-      String needWantType,
-      String title,
-      String memo)
-      throws Exception {
-    var memoField = memo != null ? ", \"memo\": \"" + memo + "\"" : "";
-    mockMvc
-        .perform(
-            post("/api/v1/transactions")
-                .header("Authorization", token)
-                .contentType(APPLICATION_JSON)
-                .content(
-                    """
-                    {
-                      "date": "%s",
-                      "amount": "%s",
-                      "category_id": %d,
-                      "need_want_type": "%s",
-                      "title": "%s"%s
-                    }
-                    """
-                        .formatted(date, amount, categoryId, needWantType, title, memoField)))
-        .andExpect(status().isCreated());
   }
 }


### PR DESCRIPTION
## 概要

統合テスト Phase 3 として、検索フィルタとAnalyticsエンドポイントの一気通貫テストを追加する。

## 変更内容

- **TransactionSearchIntegrationTest**: 支出検索エンドポイント (`GET /api/v1/transactions`) の統合テスト
  - 日付範囲フィルタ、カテゴリフィルタ（単一・複数）、NeedWantTypeフィルタ、キーワード部分一致検索
  - 複数フィルタのAND結合、ユーザー間データ分離の検証
- **AnalyticsIntegrationTest**: 分析エンドポイントの統合テスト
  - カテゴリ別集計 (`GET /api/v1/analytics/category`): 金額・件数・期間フィルタ、取引なし時の全カテゴリ返却
  - Need/Want比率 (`GET /api/v1/analytics/need-want`): 金額・件数、取引なし時の全タイプ返却
  - ユーザー間データ分離の検証

## 関連 Issue

Closes #161

## テスト

```bash
./gradlew integrationTest   # IT のみ実行 → 全14テスト Green
./gradlew build              # 全体ビルド成功（Checkstyle・Spotless含む）
```

---
🤖 Generated with [Claude Code](https://claude.ai/code)