### PR TITLE
refactor(exception): FieldError.pointerをfieldにリネーム

### DIFF
--- a/backend/src/main/java/com/youmorry/expensetracker/presentation/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/youmorry/expensetracker/presentation/GlobalExceptionHandler.java
@@ -43,7 +43,7 @@ public class GlobalExceptionHandler {
     if (ex instanceof ValidationException validationEx) {
       List<Map<String, String>> errors =
           validationEx.getErrors().stream()
-              .map(e -> Map.of("detail", e.detail(), "pointer", "#/" + toSnakeCase(e.pointer())))
+              .map(e -> Map.of("detail", e.detail(), "pointer", "#/" + toSnakeCase(e.field())))
               .toList();
       problem.setProperty("errors", errors);
     }

--- a/backend/src/main/java/com/youmorry/expensetracker/shared/exception/ValidationException.java
+++ b/backend/src/main/java/com/youmorry/expensetracker/shared/exception/ValidationException.java
@@ -25,7 +25,7 @@ public class ValidationException extends AppException {
    * フィールドごとのエラー詳細を表すレコード。
    *
    * @param detail エラーの詳細な説明
-   * @param pointer エラーが発生したフィールドを（例: "currencyCode"）
+   * @param field エラーが発生した Java フィールドの論理名（例: "categoryId"）
    */
-  public record FieldError(String detail, String pointer) {}
+  public record FieldError(String detail, String field) {}
 }

--- a/docs/03-design/error-handling.md
+++ b/docs/03-design/error-handling.md
@@ -48,7 +48,7 @@ RuntimeException
 
 - `RuntimeException` を継承する抽象クラス
 - 各サブクラスのコンストラクタは `detail`（エラーメッセージ）のみを受け取り、`type` / `title` / `status` はクラス内で固定する
-- `ValidationException` は追加で `List<FieldError>` を保持する。`FieldError` は `detail`（エラーメッセージ）と `pointer`（Java フィールドの論理名、camelCase）を持つ record とする。Presentation 層で JSON Pointer 形式（`#/snake_case`）に変換する
+- `ValidationException` は追加で `List<FieldError>` を保持する。`FieldError` は `detail`（エラーメッセージ）と `field`（Java フィールドの論理名、camelCase）を持つ record とする。Presentation 層で JSON Pointer 形式（`#/snake_case`）に変換する
 
 ### グローバル例外ハンドラ
 


### PR DESCRIPTION
## 概要
`ValidationException.FieldError` の `pointer` フィールドを `field` にリネームし、API レスポンス概念（JSON Pointer）が application 層に漏れないようにする。

## 変更内容
- `FieldError` record の `pointer` → `field` にリネーム（ドメイン層として適切な命名に変更）
- `GlobalExceptionHandler` で `e.field()` を参照するように変更（JSON Pointer 形式への変換は presentation 層に閉じる）
- `docs/03-design/error-handling.md` のドキュメントを更新

## 関連 Issue
Closes #180

## テスト
- `./gradlew build` で単体テスト・統合テスト・Checkstyle・Spotless 含め全て成功を確認済み

---
🤖 Generated with [Claude Code](https://claude.ai/code)