### PR TITLE
feat(build): RequireExplicitNullMarkingチェッカーを追加

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -107,18 +107,21 @@ tasks.withType<JavaCompile>().configureEach {
         check("NullAway", CheckSeverity.ERROR)
         option("NullAway:JSpecifyMode", "true")
         option("NullAway:OnlyNullMarked", "true")
+        check("RequireExplicitNullMarking", CheckSeverity.ERROR)
     }
 }
 
 tasks.named<JavaCompile>("compileTestJava") {
     options.errorprone {
         check("NullAway", CheckSeverity.OFF)
+        check("RequireExplicitNullMarking", CheckSeverity.OFF)
     }
 }
 
 tasks.named<JavaCompile>("compileIntegrationTestJava") {
     options.errorprone {
         check("NullAway", CheckSeverity.OFF)
+        check("RequireExplicitNullMarking", CheckSeverity.OFF)
     }
 }
 


### PR DESCRIPTION
## 概要

NullAway同梱の`RequireExplicitNullMarking`チェッカーをERRORレベルで有効化し、新規パッケージでの`@NullMarked`付与漏れをビルド時に検出できるようにする。

## 変更内容

- `build.gradle.kts`の`tasks.withType<JavaCompile>()`ブロックに`RequireExplicitNullMarking`をERRORレベルで追加
- テストコード（`compileTestJava`, `compileIntegrationTestJava`）ではOFFに設定

## 関連 Issue

Closes #197

## テスト

- `./gradlew build` が成功することを確認済み
- `package-info.java`を一時的に削除した状態でビルドが失敗することを確認済み（チェッカーが正しく動作）

---
🤖 Generated with [Claude Code](https://claude.ai/code)