### PR TITLE
fix(build): コンパイル時・Checkstyleのwarningを修正

### DIFF
--- a/backend/src/integrationTest/java/com/youmorry/expensetracker/integration/AbstractIntegrationTest.java
+++ b/backend/src/integrationTest/java/com/youmorry/expensetracker/integration/AbstractIntegrationTest.java
@@ -128,7 +128,7 @@ abstract class AbstractIntegrationTest {
         .andExpect(status().isCreated());
   }
 
-  /** memo なしの取引作成ヘルパー。 */
+  /** メモなしの取引作成ヘルパー。 */
   protected void createTransaction(
       String token, String date, String amount, int categoryId, String needWantType, String title)
       throws Exception {

--- a/backend/src/main/java/com/youmorry/expensetracker/domain/category/CategoryId.java
+++ b/backend/src/main/java/com/youmorry/expensetracker/domain/category/CategoryId.java
@@ -1,10 +1,13 @@
 package com.youmorry.expensetracker.domain.category;
 
+import com.google.errorprone.annotations.Immutable;
+
 /**
  * Value Object: Category ID。
  *
  * @param value Category ID
  */
+@Immutable
 public record CategoryId(long value) {
   /**
    * ID が正の値であることを検証する。

--- a/backend/src/test/java/com/youmorry/expensetracker/infrastructure/security/JwtProviderTest.java
+++ b/backend/src/test/java/com/youmorry/expensetracker/infrastructure/security/JwtProviderTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.youmorry.expensetracker.domain.user.UserId;
+import java.nio.charset.StandardCharsets;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import javax.crypto.spec.SecretKeySpec;
@@ -15,7 +16,8 @@ class JwtProviderTest {
 
   // 32 bytes of key material, Base64-encoded
   private static final String SECRET =
-      Base64.getEncoder().encodeToString("test-secret-key-at-least-32-byte".getBytes());
+      Base64.getEncoder()
+          .encodeToString("test-secret-key-at-least-32-byte".getBytes(StandardCharsets.UTF_8));
   private static final String ISSUER = "https://test.example.com";
   private static final long EXPIRATION_HOURS = 24;
 

--- a/backend/src/test/java/com/youmorry/expensetracker/infrastructure/security/SecurityConfigTest.java
+++ b/backend/src/test/java/com/youmorry/expensetracker/infrastructure/security/SecurityConfigTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.youmorry.expensetracker.domain.user.UserId;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,7 +23,8 @@ class SecurityConfigTest {
 
   // 32 bytes of key material, Base64-encoded
   private static final String SECRET =
-      Base64.getEncoder().encodeToString("test-secret-key-at-least-32-byte".getBytes());
+      Base64.getEncoder()
+          .encodeToString("test-secret-key-at-least-32-byte".getBytes(StandardCharsets.UTF_8));
   private static final String ISSUER = "https://test.example.com";
 
   @Autowired private MockMvc mockMvc;
@@ -54,7 +56,8 @@ class SecurityConfigTest {
   void jwtDecoder_withShortSecret_throwsIllegalArgumentException() {
     SecurityConfig config = new SecurityConfig();
     // Base64 of "short" (only 5 bytes, less than 32)
-    String shortBase64 = Base64.getEncoder().encodeToString("short".getBytes());
+    String shortBase64 =
+        Base64.getEncoder().encodeToString("short".getBytes(StandardCharsets.UTF_8));
     assertThrows(IllegalArgumentException.class, () -> config.jwtDecoder(shortBase64, ISSUER));
   }
 
@@ -62,7 +65,8 @@ class SecurityConfigTest {
   void jwtDecoder_with32ByteSecret_returnsDecoder() {
     SecurityConfig config = new SecurityConfig();
     String validBase64 =
-        Base64.getEncoder().encodeToString("valid-secret-key-that-is-32-byte".getBytes());
+        Base64.getEncoder()
+            .encodeToString("valid-secret-key-that-is-32-byte".getBytes(StandardCharsets.UTF_8));
     assertNotNull(config.jwtDecoder(validBase64, ISSUER));
   }
 


### PR DESCRIPTION
## 概要
`./gradlew build` 実行時に出力されていた Error Prone および Checkstyle の warning を修正する。

## 変更内容
- `CategoryId` に `@Immutable` アノテーションを追加（ImmutableEnumChecker warning 解消）
- テストコードの `.getBytes()` に `StandardCharsets.UTF_8` を明示指定（DefaultCharset warning 4件解消）
- Javadoc の先頭を日本語に変更し Checkstyle SummaryJavadoc の forbidden pattern を回避

## 対応不要と判断した warning
- **sun.misc.Unsafe** — Error Prone が依存する Guava 33.4.0 の内部 warning。コンパイル時ツールの依存でありアプリ実行時には影響なし
- **JVM Sharing warning** — Testcontainers/Spring Boot テスト実行時の JVM 内部 warning

## 関連 Issue
Closes #198

## テスト
- `./gradlew clean build` で対応対象の warning が出力されないことを確認済み
- 全テスト（unit / integration）がパスすることを確認済み

---
🤖 Generated with [Claude Code](https://claude.ai/code)