### PR TITLE
feat(security): CORS設定を追加

### DIFF
--- a/backend/src/main/java/com/youmorry/expensetracker/infrastructure/security/SecurityConfig.java
+++ b/backend/src/main/java/com/youmorry/expensetracker/infrastructure/security/SecurityConfig.java
@@ -1,6 +1,8 @@
 package com.youmorry.expensetracker.infrastructure.security;
 
+import java.util.Arrays;
 import java.util.Base64;
+import java.util.List;
 import javax.crypto.spec.SecretKeySpec;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -13,6 +15,8 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 /** Spring Security の設定。 */
 @Configuration
@@ -22,7 +26,8 @@ public class SecurityConfig {
   /** セキュリティフィルターチェーンを構成する。 */
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-    http.csrf(csrf -> csrf.disable())
+    http.cors(Customizer.withDefaults())
+        .csrf(csrf -> csrf.disable())
         .sessionManagement(
             session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
@@ -30,6 +35,23 @@ public class SecurityConfig {
             auth ->
                 auth.requestMatchers("/api/v1/auth/**").permitAll().anyRequest().authenticated());
     return http.build();
+  }
+
+  /** CORS の許可設定を構成する。 */
+  @Bean
+  public UrlBasedCorsConfigurationSource corsConfigurationSource(
+      @Value("${app.cors.allowed-origins:}") String allowedOrigins) {
+    CorsConfiguration configuration = new CorsConfiguration();
+    if (!allowedOrigins.isBlank()) {
+      configuration.setAllowedOrigins(
+          Arrays.stream(allowedOrigins.split(",")).map(String::trim).toList());
+    }
+    configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+    configuration.setAllowedHeaders(List.of("Authorization", "Content-Type"));
+    configuration.setAllowCredentials(true);
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", configuration);
+    return source;
   }
 
   /** HS256 で署名された JWT を検証する {@link JwtDecoder} を構成する。issuer の一致も検証する。 */

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -9,6 +9,8 @@ spring:
     password: postgres
 
 app:
+  cors:
+    allowed-origins: http://localhost:5173,http://localhost:8081
   auth:
     google-client-id: dummy-client-id
     jwt-secret: ZGV2LXNlY3JldC1rZXktYXQtbGVhc3QtMzItYnl0ZXMh

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -15,6 +15,8 @@ spring:
     default-property-inclusion: NON_NULL
 
 app:
+  cors:
+    allowed-origins: ${CORS_ALLOWED_ORIGINS:}
   auth:
     google-client-id: ${GOOGLE_CLIENT_ID}
     # Base64-encoded secret key (generate with: openssl rand -base64 32)

--- a/backend/src/test/java/com/youmorry/expensetracker/infrastructure/security/SecurityConfigTest.java
+++ b/backend/src/test/java/com/youmorry/expensetracker/infrastructure/security/SecurityConfigTest.java
@@ -106,7 +106,8 @@ class SecurityConfigTest {
                 .header(HttpHeaders.ORIGIN, "http://localhost:5173")
                 .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "GET"))
         .andExpect(status().isOk())
-        .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "http://localhost:5173"))
+        .andExpect(
+            header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "http://localhost:5173"))
         .andExpect(header().exists(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS));
   }
 

--- a/backend/src/test/java/com/youmorry/expensetracker/infrastructure/security/SecurityConfigTest.java
+++ b/backend/src/test/java/com/youmorry/expensetracker/infrastructure/security/SecurityConfigTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.youmorry.expensetracker.domain.user.UserId;
@@ -13,12 +15,16 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtValidationException;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(SecurityTestController.class)
 @Import(SecurityConfig.class)
+@TestPropertySource(
+    properties = "app.cors.allowed-origins=http://localhost:5173,http://localhost:8081")
 class SecurityConfigTest {
 
   // 32 bytes of key material, Base64-encoded
@@ -90,5 +96,27 @@ class SecurityConfigTest {
     String token = provider.generateToken(new UserId(1L), "test@gmail.com");
 
     assertNotNull(decoder.decode(token));
+  }
+
+  @Test
+  void preflightRequest_fromAllowedOrigin_returnsOk() throws Exception {
+    mockMvc
+        .perform(
+            options("/api/v1/test")
+                .header(HttpHeaders.ORIGIN, "http://localhost:5173")
+                .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "GET"))
+        .andExpect(status().isOk())
+        .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "http://localhost:5173"))
+        .andExpect(header().exists(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS));
+  }
+
+  @Test
+  void preflightRequest_fromDisallowedOrigin_returnsForbidden() throws Exception {
+    mockMvc
+        .perform(
+            options("/api/v1/test")
+                .header(HttpHeaders.ORIGIN, "http://evil.example.com")
+                .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "GET"))
+        .andExpect(status().isForbidden());
   }
 }


### PR DESCRIPTION
## 概要

フロントエンド（React + Vite）や Scalar（API リファレンス UI）が別オリジンで動作する際に、バックエンドへのリクエストが CORS でブロックされる問題を解決する。

## 変更内容

- `SecurityConfig` に `CorsConfigurationSource` Bean を追加（Spring Security 7.0 推奨方式）
- 許可オリジンを `app.cors.allowed-origins` プロパティで環境ごとに管理可能にした
- ローカル環境では `http://localhost:5173`（Vite）と `http://localhost:8081`（Scalar）を許可
- 許可メソッド: GET, POST, PUT, DELETE, OPTIONS
- 許可ヘッダー: Authorization, Content-Type
- プリフライトリクエストの検証テストを追加（許可/未許可オリジン）

## 関連 Issue

Closes #76

## テスト

- `SecurityConfigTest` に CORS プリフライトリクエストのテストを追加
  - 許可オリジンからの OPTIONS → 200 + 正しい CORS ヘッダー
  - 未許可オリジンからの OPTIONS → 403
- `./gradlew build` 全テスト・Checkstyle・Spotless 通過確認済み

---
🤖 Generated with [Claude Code](https://claude.ai/code)