### PR TITLE
fix(backend): Error ProneとNullAwayをDependabotの同一グループに統合

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,12 @@ updates:
       google:
         patterns:
           - "com.google*"
+        exclude-patterns:
+          - "com.google.errorprone*"
+      error-prone:
+        patterns:
+          - "com.google.errorprone*"
+          - "com.uber.nullaway*"
       minor-and-patch:
         update-types:
           - minor
@@ -30,6 +36,7 @@ updates:
           - "org.springframework*"
           - "org.testcontainers*"
           - "com.google*"
+          - "com.uber.nullaway*"
     ignore:
       - dependency-name: "*"
         update-types:


### PR DESCRIPTION
## 概要

Error ProneとNullAwayがDependabotの別グループに分かれていたため、片方だけ更新されるPRが作成されビルドが失敗していた（#216, #217）。

## 変更内容

- `error-prone` グループを新設し、`com.google.errorprone*` と `com.uber.nullaway*` をまとめる
- `google` グループから Error Prone を除外
- `minor-and-patch` グループから NullAway を除外

## 確認手順

- [ ] マージ後、PR #216 と #217 を閉じる
- [ ] Dependabot に再実行させ、Error Prone + NullAway が同一PRで更新されることを確認する

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)