### PR TITLE
fix(backend): 未使用のspringdoc-openapi依存を削除

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -36,7 +36,6 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-flyway")
     implementation("org.flywaydb:flyway-database-postgresql")
     runtimeOnly("org.postgresql:postgresql")
-    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6")
     implementation("com.google.guava:guava:33.5.0-jre")
     implementation("com.google.api-client:google-api-client:2.9.0")
     implementation("org.jspecify:jspecify:1.0.0")


### PR DESCRIPTION
## Summary
- Spring Boot 4.0と非互換な `springdoc-openapi-starter-webmvc-ui` の依存を `build.gradle.kts` から削除
- APIドキュメントはDocker ComposeのScalarコンテナで提供しており、springdocはソースコード内で一切使用されていなかった
- これにより #224 (Dependabotによるspringdocバージョンアップ) のCI失敗も解消される

## Background
- Dependabot PR #224 でspringdoc 2.8.6 → 2.8.17 へのアップデートが提案されたが、全インテグレーションテストが `ClassNotFoundException: org.springframework.boot.autoconfigure.web.servlet.WebMvcProperties` で失敗
- springdoc 2.x は Spring Boot 3.x 向けであり、本プロジェクトのSpring Boot 4.0とは非互換
- 調査の結果、そもそもspringdocはコード内で使用されていないことが判明

## Test plan
- [x] `./gradlew build` 成功（単体テスト・統合テスト・Checkstyle・Spotless含む）

closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)