### PR TITLE
feat(auth): インメモリJWTトークンストアを追加

### DIFF
--- a/frontend/src/lib/auth.test.ts
+++ b/frontend/src/lib/auth.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { clearToken, getToken, setToken } from "./auth";
+
+describe("auth token store", () => {
+  beforeEach(() => {
+    clearToken();
+  });
+
+  it("returns null when no token is set", () => {
+    const result = getToken();
+
+    expect(result).toBeNull();
+  });
+
+  it("returns token after setToken is called", () => {
+    setToken("jwt-token-123");
+
+    expect(getToken()).toBe("jwt-token-123");
+  });
+
+  it("returns null after clearToken is called", () => {
+    setToken("jwt-token-123");
+
+    clearToken();
+
+    expect(getToken()).toBeNull();
+  });
+
+  it("returns latest token when setToken is called multiple times", () => {
+    setToken("first-token");
+    setToken("second-token");
+
+    expect(getToken()).toBe("second-token");
+  });
+});

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,0 +1,13 @@
+let token: string | null = null;
+
+export function getToken(): string | null {
+  return token;
+}
+
+export function setToken(newToken: string): void {
+  token = newToken;
+}
+
+export function clearToken(): void {
+  token = null;
+}


### PR DESCRIPTION
## 概要
JWT トークンをモジュールレベル変数でインメモリ管理するモジュールを追加。localStorage / Cookie を使用せず、XSS によるトークン窃取リスクを最小化する。

## 変更内容
- `frontend/src/lib/auth.ts` — `getToken()` / `setToken()` / `clearToken()` を実装
- `frontend/src/lib/auth.test.ts` — ユニットテスト 4件（初期値 null、設定・取得、クリア、上書き）

## 関連 Issue
Closes #236

## テスト
- `npm test -- --run src/lib/auth.test.ts` で全 4件通過を確認
- `npm run build` でビルド成功を確認

---
🤖 Generated with [Claude Code](https://claude.ai/code)