### PR TITLE
feat(frontend): null安全の対応（strict モード + strictTypeChecked）

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -124,7 +124,7 @@ function TransactionForm() {
 
 ## リンティング・フォーマッティング
 
-- ESLint: `typescript-eslint` の `recommendedTypeChecked` を使用
+- ESLint: `typescript-eslint` の `strictTypeChecked` を使用
 - Prettier: `printWidth: 100`、`prettier-plugin-tailwindcss` でクラス名のソートを自動化
 - コード変更時は `npm run lint` と `npm run format:check` でチェックする
 - フルチェックは `npm run check`（Prettier + ESLint + tsc + Vitest + build）

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -9,7 +9,7 @@ export default tseslint.config(
   { ignores: ["dist/"] },
   {
     files: ["**/*.{ts,tsx}"],
-    extends: [js.configs.recommended, ...tseslint.configs.recommendedTypeChecked],
+    extends: [js.configs.recommended, ...tseslint.configs.strictTypeChecked],
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
@@ -17,6 +17,10 @@ export default tseslint.config(
         projectService: true,
         tsconfigRootDir: import.meta.dirname,
       },
+    },
+    rules: {
+      "@typescript-eslint/no-non-null-assertion": "error",
+      "@typescript-eslint/consistent-type-assertions": ["error", { assertionStyle: "never" }],
     },
   },
   reactHooks.configs.flat.recommended,

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  ...(process.env.CI ? { workers: 1 } : {}),
   reporter: process.env.CI ? [["github"], ["html"]] : "html",
   use: {
     baseURL: "http://localhost:4173",

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,7 +3,12 @@ import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.tsx";
 
-createRoot(document.getElementById("root")!).render(
+const root = document.getElementById("root");
+if (!root) {
+  throw new Error("Root element not found");
+}
+
+createRoot(root).render(
   <StrictMode>
     <App />
   </StrictMode>,

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -2,6 +2,12 @@ import "@testing-library/jest-dom/vitest";
 import { afterAll, afterEach, beforeAll } from "vitest";
 import { server } from "./mocks/server";
 
-beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
-afterEach(() => server.resetHandlers());
-afterAll(() => server.close());
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: "error" });
+});
+afterEach(() => {
+  server.resetHandlers();
+});
+afterAll(() => {
+  server.close();
+});

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -7,6 +7,11 @@
     "types": ["vite/client", "vitest/globals"],
     "skipLibCheck": true,
 
+    /* Strict type checking */
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -7,6 +7,11 @@
     "types": ["node"],
     "skipLibCheck": true,
 
+    /* Strict type checking */
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,


### PR DESCRIPTION
## 概要
フロントエンドの null 安全を強化する。TypeScript の strict モードを有効化し、ESLint を strictTypeChecked にアップグレードすることで、Java 側の JSpecify + NullAway に相当する厳密さを実現する。

## 変更内容
- `tsconfig.app.json` / `tsconfig.node.json` に `strict: true`, `noUncheckedIndexedAccess: true`, `exactOptionalPropertyTypes: true` を追加
- ESLint を `recommendedTypeChecked` → `strictTypeChecked` にアップグレード
- `no-non-null-assertion: error` と `consistent-type-assertions: ['error', { assertionStyle: 'never' }]` ルールを追加し、`!` 演算子と `as` キャストを禁止
- `main.tsx` の非nullアサーション（`!`）をランタイムチェックに置換
- `setup.ts` の `no-confusing-void-expression` 違反を修正（アロー関数にブレース追加）
- `playwright.config.ts` の `exactOptionalPropertyTypes` 互換性を修正
- `.claude/rules/frontend.md` のリンティング記述を更新

## 関連 Issue
Closes #262

## テスト
- `npx tsc -p tsconfig.app.json --noEmit` — エラーなし
- `npx tsc -p tsconfig.node.json --noEmit` — エラーなし
- `npx eslint --no-cache .` — エラーなし
- `npm run build` — ビルド成功

---
🤖 Generated with [Claude Code](https://claude.ai/code)