### PR TITLE
feat(auth): 認証ガード（AuthGuard）コンポーネントを追加

### DIFF
--- a/frontend/src/components/AuthGuard.test.tsx
+++ b/frontend/src/components/AuthGuard.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { createMemoryRouter, RouterProvider } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/auth", () => ({
+  getToken: vi.fn(),
+}));
+
+import { getToken } from "../lib/auth";
+import { AuthGuard } from "./AuthGuard";
+
+const mockedGetToken = vi.mocked(getToken);
+
+function renderWithAuthGuard(initialEntry: string) {
+  const router = createMemoryRouter(
+    [
+      { path: "/login", element: <h1>Login</h1> },
+      {
+        Component: AuthGuard,
+        children: [{ path: "/protected", element: <h1>Protected</h1> }],
+      },
+    ],
+    { initialEntries: [initialEntry] },
+  );
+  render(<RouterProvider router={router} />);
+  return router;
+}
+
+describe("AuthGuard", () => {
+  beforeEach(() => {
+    mockedGetToken.mockReturnValue(null);
+  });
+
+  it("redirects to login when token is absent", async () => {
+    const router = renderWithAuthGuard("/protected");
+
+    await screen.findByRole("heading", { name: "Login" });
+    expect(router.state.location.pathname).toBe("/login");
+  });
+
+  it("renders child route when token is present", async () => {
+    mockedGetToken.mockReturnValue("valid-token");
+
+    renderWithAuthGuard("/protected");
+
+    await screen.findByRole("heading", { name: "Protected" });
+  });
+});

--- a/frontend/src/components/AuthGuard.tsx
+++ b/frontend/src/components/AuthGuard.tsx
@@ -1,0 +1,10 @@
+import { Navigate, Outlet } from "react-router";
+
+import { getToken } from "../lib/auth";
+
+export function AuthGuard() {
+  if (!getToken()) {
+    return <Navigate to="/login" replace />;
+  }
+  return <Outlet />;
+}

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -1,41 +1,36 @@
 import type { RouteObject } from "react-router";
 import { redirect } from "react-router";
 
-import { getToken } from "./lib/auth";
+import { AuthGuard } from "./components/AuthGuard";
 import AnalyticsPage from "./features/analytics/components/AnalyticsPage";
 import LoginPage from "./features/auth/components/LoginPage";
 import SettingsPage from "./features/settings/components/SettingsPage";
 import TransactionsPage from "./features/transactions/components/TransactionsPage";
 
-function requireAuth() {
-  if (!getToken()) {
-    return redirect("/login");
-  }
-  return null;
-}
-
 export const routes: RouteObject[] = [
-  {
-    path: "/",
-    loader: () => redirect("/transactions"),
-  },
   {
     path: "/login",
     Component: LoginPage,
   },
   {
-    path: "/transactions",
-    Component: TransactionsPage,
-    loader: requireAuth,
-  },
-  {
-    path: "/analytics",
-    Component: AnalyticsPage,
-    loader: requireAuth,
-  },
-  {
-    path: "/settings",
-    Component: SettingsPage,
-    loader: requireAuth,
+    Component: AuthGuard,
+    children: [
+      {
+        path: "/",
+        loader: () => redirect("/transactions"),
+      },
+      {
+        path: "/transactions",
+        Component: TransactionsPage,
+      },
+      {
+        path: "/analytics",
+        Component: AnalyticsPage,
+      },
+      {
+        path: "/settings",
+        Component: SettingsPage,
+      },
+    ],
   },
 ];


### PR DESCRIPTION
## 概要

未認証ユーザーをログイン画面にリダイレクトする AuthGuard コンポーネントを実装し、ルート定義をレイアウトルートパターンに統合した。

## 変更内容

- `AuthGuard` コンポーネントを作成（`getToken()` でトークン確認、未認証時は `/login` にリダイレクト）
- `routes.tsx` を AuthGuard レイアウトルートに統合し、各ルートの個別 `requireAuth` ローダーを廃止
- AuthGuard のユニットテストを追加（トークンなし→リダイレクト、トークンあり→子要素表示）

## 関連 Issue

Closes #239

## テスト

- `npm run check` 全通過（Prettier / ESLint / tsc / Vitest 62テスト / Playwright E2E / ビルド）
- AuthGuard 単体テスト: トークンなし→ `/login` リダイレクト、トークンあり→子ルート表示

---
🤖 Generated with [Claude Code](https://claude.ai/code)