### PR TITLE
feat(frontend): TanStack Query v5 セットアップ

### DIFF
--- a/docs/03-design/common/error-handling.md
+++ b/docs/03-design/common/error-handling.md
@@ -150,23 +150,15 @@ API クライアント（fetch ラッパー）でレスポンスステータス�
 
 #### リトライ方針
 
-API クライアント層で指数バックオフリトライを行う（最大 3 回）。
-クライアント起因のエラー（4xx）はリトライしても結果が変わらないため、以下のステータスコードはリトライ対象外とする:
-
-- 400 Bad Request（JSON パースエラー、パラメータ型不正）
-- 401 Unauthorized（認証エラー）
-- 403 Forbidden（認可エラー）
-- 404 Not Found（リソース不在）
-- 422 Unprocessable Content（バリデーションエラー）
-
-上記以外（5xx、ネットワークエラー）は最大 3 回リトライする。
+API クライアント層ではリトライを行わない。リトライは TanStack Query の QueryClient が一元管理する。
 
 ### TanStack Query でのエラーハンドリング
 
 #### リトライ方針
 
-API クライアント層でリトライを行うため、TanStack Query の `retry` は無効化する（`retry: false`）。
+QueryClient のデフォルト設定でリトライポリシーを定義する（`src/lib/queryClient.ts`）。
 
+- Query: クライアントエラー（4xx）はリトライしない。サーバーエラー（5xx）・ネットワークエラーは最大 3 回リトライする
 - Mutation: リトライしない
 
 #### Mutation のエラー処理

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,8 @@
       "name": "expense-tracker-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.99.0",
+        "@tanstack/react-query-devtools": "^5.99.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-router": "^7.14.1",
@@ -1528,6 +1530,59 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.0.tgz",
+      "integrity": "sha512-3Jv3WQG0BCcH7G+7lf/bP8QyBfJOXeY+T08Rin3GZ1bshvwlbPt7NrDHMEzGdKIOmOzvIQmxjk28YEQX60k7pQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.99.0.tgz",
+      "integrity": "sha512-m4ufXaJ8FjWXw7xDtyzE/6fkZAyQFg9WrbMrUpt8ZecRJx58jiFOZ2lxZMphZdIpAnIeto/S8stbwLKLusyckQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.0.tgz",
+      "integrity": "sha512-OY2bCqPemT1LlqJ8Y2CUau4KELnIhhG9Ol3ZndPbdnB095pRbPo1cHuXTndg8iIwtoHTgwZjyaDnQ0xD0mYwAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.99.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.99.0.tgz",
+      "integrity": "sha512-CqqX7LCU9yOfCY/vBURSx2YSD83ryfX+QkfkaKionTfg1s2Hdm572Ro99gW3QPoJjzvsj1HM4pnN4nbDy3MXKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.99.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.99.0",
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,8 @@
     "check": "prettier --check . && eslint . && tsc -b && vitest run && playwright test && vite build"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.99.0",
+    "@tanstack/react-query-devtools": "^5.99.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router": "^7.14.1",

--- a/frontend/src/lib/api/client.test.ts
+++ b/frontend/src/lib/api/client.test.ts
@@ -2,11 +2,11 @@
  * API クライアントのテスト。
  *
  * MSW を使用してHTTPリクエストをインターセプトし、
- * リクエスト送信・レスポンス解析・エラーハンドリング・リトライの動作を検証する。
+ * リクエスト送信・レスポンス解析・エラーハンドリングの動作を検証する。
  */
 
 import { http, HttpResponse } from "msw";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import type { ApiError } from "../../types/api";
 import { server } from "../../test/mocks/server";
 import * as auth from "../auth";
@@ -214,7 +214,6 @@ describe("apiClient", () => {
     });
 
     it("throws ApiException when error response is not JSON", async () => {
-      vi.useFakeTimers();
       server.use(
         http.get(`${BASE_URL}/test`, () => {
           return new HttpResponse("<html>Bad Gateway</html>", {
@@ -224,32 +223,25 @@ describe("apiClient", () => {
         }),
       );
 
-      const promise = apiClient.get(`${BASE_URL}/test`).catch((e: unknown) => e);
-      await vi.advanceTimersByTimeAsync(10_000);
-      const error = await promise;
+      const error = await apiClient.get(`${BASE_URL}/test`).catch((e: unknown) => e);
 
       expect(error).toBeInstanceOf(ApiException);
       if (error instanceof ApiException) {
         expect(error.status).toBe(502);
         expect(error.apiError.type).toBe("about:blank");
       }
-      vi.useRealTimers();
     });
 
     it("throws NetworkException on network failure", async () => {
-      vi.useFakeTimers();
       server.use(
         http.get(`${BASE_URL}/test`, () => {
           return HttpResponse.error();
         }),
       );
 
-      const promise = apiClient.get(`${BASE_URL}/test`).catch((e: unknown) => e);
-      await vi.advanceTimersByTimeAsync(10_000);
-      const error = await promise;
+      const error = await apiClient.get(`${BASE_URL}/test`).catch((e: unknown) => e);
 
       expect(error).toBeInstanceOf(NetworkException);
-      vi.useRealTimers();
     });
   });
 
@@ -292,165 +284,6 @@ describe("apiClient", () => {
       if (error instanceof ApiException) {
         expect(error.status).toBe(401);
       }
-    });
-  });
-
-  describe("retry", () => {
-    beforeEach(() => {
-      vi.useFakeTimers();
-    });
-
-    afterEach(() => {
-      vi.useRealTimers();
-    });
-
-    it("retries on 500 error up to 3 times", async () => {
-      let callCount = 0;
-      const apiError: ApiError = {
-        type: "https://example.com/server-error",
-        title: "Internal Server Error",
-        status: 500,
-        detail: "Server error",
-      };
-      server.use(
-        http.get(`${BASE_URL}/test`, () => {
-          callCount++;
-          return HttpResponse.json(apiError, { status: 500 });
-        }),
-      );
-
-      const promise = apiClient.get(`${BASE_URL}/test`).catch(() => {});
-      await vi.advanceTimersByTimeAsync(10_000);
-      await promise;
-
-      expect(callCount).toBe(4); // 1 initial + 3 retries
-    });
-
-    it("returns response when retry succeeds", async () => {
-      let callCount = 0;
-      const apiError: ApiError = {
-        type: "https://example.com/server-error",
-        title: "Internal Server Error",
-        status: 500,
-        detail: "Server error",
-      };
-      server.use(
-        http.get(`${BASE_URL}/test`, () => {
-          callCount++;
-          if (callCount < 3) {
-            return HttpResponse.json(apiError, { status: 500 });
-          }
-          return HttpResponse.json({ id: 1 });
-        }),
-      );
-
-      const promise = apiClient.get(`${BASE_URL}/test`);
-      await vi.advanceTimersByTimeAsync(10_000);
-      const result = await promise;
-
-      expect(result).toEqual({ id: 1 });
-      expect(callCount).toBe(3);
-    });
-
-    it("does not retry on 401", async () => {
-      let callCount = 0;
-      const apiError: ApiError = {
-        type: "https://example.com/unauthorized",
-        title: "Unauthorized",
-        status: 401,
-        detail: "Invalid token",
-      };
-      server.use(
-        http.get(`${BASE_URL}/test`, () => {
-          callCount++;
-          return HttpResponse.json(apiError, { status: 401 });
-        }),
-      );
-
-      await apiClient.get(`${BASE_URL}/test`).catch(() => {});
-
-      expect(callCount).toBe(1);
-    });
-
-    it("does not retry on 403", async () => {
-      let callCount = 0;
-      const apiError: ApiError = {
-        type: "https://example.com/forbidden",
-        title: "Forbidden",
-        status: 403,
-        detail: "Access denied",
-      };
-      server.use(
-        http.get(`${BASE_URL}/test`, () => {
-          callCount++;
-          return HttpResponse.json(apiError, { status: 403 });
-        }),
-      );
-
-      await apiClient.get(`${BASE_URL}/test`).catch(() => {});
-
-      expect(callCount).toBe(1);
-    });
-
-    it("does not retry on 404", async () => {
-      let callCount = 0;
-      const apiError: ApiError = {
-        type: "https://example.com/not-found",
-        title: "Not Found",
-        status: 404,
-        detail: "Not found",
-      };
-      server.use(
-        http.get(`${BASE_URL}/test`, () => {
-          callCount++;
-          return HttpResponse.json(apiError, { status: 404 });
-        }),
-      );
-
-      await apiClient.get(`${BASE_URL}/test`).catch(() => {});
-
-      expect(callCount).toBe(1);
-    });
-
-    it("does not retry on 400", async () => {
-      let callCount = 0;
-      const apiError: ApiError = {
-        type: "https://example.com/bad-request",
-        title: "Bad Request",
-        status: 400,
-        detail: "Invalid request",
-      };
-      server.use(
-        http.get(`${BASE_URL}/test`, () => {
-          callCount++;
-          return HttpResponse.json(apiError, { status: 400 });
-        }),
-      );
-
-      await apiClient.get(`${BASE_URL}/test`).catch(() => {});
-
-      expect(callCount).toBe(1);
-    });
-
-    it("does not retry on 422", async () => {
-      let callCount = 0;
-      const apiError: ApiError = {
-        type: "https://example.com/validation-error",
-        title: "Unprocessable Entity",
-        status: 422,
-        detail: "Validation failed",
-        errors: [{ detail: "Amount is required", pointer: "#/amount" }],
-      };
-      server.use(
-        http.post(`${BASE_URL}/test`, () => {
-          callCount++;
-          return HttpResponse.json(apiError, { status: 422 });
-        }),
-      );
-
-      await apiClient.post(`${BASE_URL}/test`, { amount: "" }).catch(() => {});
-
-      expect(callCount).toBe(1);
     });
   });
 });

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -5,8 +5,9 @@
  * - JWT 認証ヘッダーの自動付与（skipAuth オプションで無効化可能）
  * - リクエストボディの camelCase → snake_case キー変換
  * - RFC 9457 Problem Details 形式のエラーレスポンス解析
- * - サーバーエラー・ネットワークエラー時の指数バックオフリトライ（最大3回）
  * - 401 レスポンス時のトークン自動クリア
+ *
+ * リトライは TanStack Query の QueryClient が担当する。
  *
  * @see docs/03-design/common/error-handling.md
  * @see docs/03-design/common/auth-design.md
@@ -16,13 +17,6 @@ import { ApiErrorSchema } from "../../types/api";
 import { clearToken, getToken } from "../auth";
 import { toSnakeCaseKeys } from "../caseConverter";
 import { ApiException, NetworkException } from "./errors";
-
-/**
- * リトライ対象外のステータスコード。
- * クライアント起因のエラーはリトライしても結果が変わらないため除外する。
- */
-const NO_RETRY_STATUSES = new Set([400, 401, 403, 404, 422]);
-const MAX_RETRIES = 3;
 
 /** リクエストごとのオプション */
 interface RequestOptions {
@@ -34,8 +28,8 @@ interface RequestOptions {
 }
 
 /**
- * 単一の HTTP リクエストを実行する。
- * リトライは行わず、レスポンスの解析とエラーハンドリングを担当する。
+ * HTTP リクエストを実行する。
+ * レスポンスの解析とエラーハンドリングを担当する。
  */
 async function request(
   method: string,
@@ -96,53 +90,18 @@ async function request(
 }
 
 /**
- * リトライ付きで HTTP リクエストを実行する。
- * サーバーエラー（5xx）やネットワークエラーは指数バックオフで最大 {@link MAX_RETRIES} 回リトライする。
- * {@link NO_RETRY_STATUSES} に含まれるステータスコードはリトライしない。
- */
-async function requestWithRetry(
-  method: string,
-  path: string,
-  body?: unknown,
-  options?: RequestOptions,
-): Promise<unknown> {
-  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-    try {
-      return await request(method, path, body, options);
-    } catch (error: unknown) {
-      const isLastAttempt = attempt === MAX_RETRIES;
-      if (isLastAttempt) {
-        throw error;
-      }
-
-      if (error instanceof ApiException && NO_RETRY_STATUSES.has(error.status)) {
-        throw error;
-      }
-
-      await new Promise((resolve) => {
-        setTimeout(resolve, 2 ** attempt * 1000);
-      });
-    }
-  }
-
-  // unreachable
-  throw new Error("Unexpected retry loop exit");
-}
-
-/**
  * API クライアント。
  *
- * 各メソッドはリトライ付きでリクエストを実行する。
  * DELETE はリクエストボディを受け付けない（API 設計上の制約）。
  */
 export const apiClient = {
   get: (path: string, options?: RequestOptions): Promise<unknown> =>
-    requestWithRetry("GET", path, undefined, options),
+    request("GET", path, undefined, options),
   post: (path: string, body?: unknown, options?: RequestOptions): Promise<unknown> =>
-    requestWithRetry("POST", path, body, options),
+    request("POST", path, body, options),
   put: (path: string, body?: unknown, options?: RequestOptions): Promise<unknown> =>
-    requestWithRetry("PUT", path, body, options),
+    request("PUT", path, body, options),
   /** DELETE はリクエストボディを受け付けない。 */
   del: (path: string, options?: RequestOptions): Promise<unknown> =>
-    requestWithRetry("DELETE", path, undefined, options),
+    request("DELETE", path, undefined, options),
 };

--- a/frontend/src/lib/queryClient.test.ts
+++ b/frontend/src/lib/queryClient.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { ApiException } from "./api/errors";
+import { shouldRetryQuery } from "./queryClient";
+
+describe("shouldRetryQuery", () => {
+  it("returns false when error is ApiException with 4xx status", () => {
+    const error = new ApiException(400, {
+      type: "about:blank",
+      title: "Bad Request",
+      status: 400,
+      detail: "Bad Request",
+    });
+
+    expect(shouldRetryQuery(0, error)).toBe(false);
+  });
+
+  it("returns false when error is ApiException with 401 status", () => {
+    const error = new ApiException(401, {
+      type: "about:blank",
+      title: "Unauthorized",
+      status: 401,
+      detail: "Unauthorized",
+    });
+
+    expect(shouldRetryQuery(0, error)).toBe(false);
+  });
+
+  it("returns false when error is ApiException with 422 status", () => {
+    const error = new ApiException(422, {
+      type: "about:blank",
+      title: "Unprocessable Entity",
+      status: 422,
+      detail: "Validation failed",
+    });
+
+    expect(shouldRetryQuery(0, error)).toBe(false);
+  });
+
+  it("returns true when error is ApiException with 500 status and failureCount < 3", () => {
+    const error = new ApiException(500, {
+      type: "about:blank",
+      title: "Internal Server Error",
+      status: 500,
+      detail: "Server error",
+    });
+
+    expect(shouldRetryQuery(0, error)).toBe(true);
+    expect(shouldRetryQuery(1, error)).toBe(true);
+    expect(shouldRetryQuery(2, error)).toBe(true);
+  });
+
+  it("returns false when error is ApiException with 500 status and failureCount >= 3", () => {
+    const error = new ApiException(500, {
+      type: "about:blank",
+      title: "Internal Server Error",
+      status: 500,
+      detail: "Server error",
+    });
+
+    expect(shouldRetryQuery(3, error)).toBe(false);
+  });
+
+  it("returns true for non-ApiException errors when failureCount < 3", () => {
+    const error = new Error("Network error");
+
+    expect(shouldRetryQuery(0, error)).toBe(true);
+    expect(shouldRetryQuery(2, error)).toBe(true);
+  });
+
+  it("returns false for non-ApiException errors when failureCount >= 3", () => {
+    const error = new Error("Network error");
+
+    expect(shouldRetryQuery(3, error)).toBe(false);
+  });
+});

--- a/frontend/src/lib/queryClient.ts
+++ b/frontend/src/lib/queryClient.ts
@@ -1,0 +1,26 @@
+import { QueryClient } from "@tanstack/react-query";
+import { ApiException } from "./api/errors";
+
+/**
+ * Query のリトライ判定関数。
+ *
+ * 4xx（クライアントエラー）はリクエスト内容の問題のためリトライしない。
+ * 5xx（サーバーエラー）やネットワークエラーは最大 3 回リトライする。
+ */
+export function shouldRetryQuery(failureCount: number, error: Error): boolean {
+  if (error instanceof ApiException && error.status < 500) {
+    return false;
+  }
+  return failureCount < 3;
+}
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: shouldRetryQuery,
+    },
+    mutations: {
+      retry: 0,
+    },
+  },
+});

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,7 +1,10 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { createBrowserRouter, RouterProvider } from "react-router";
 import "./index.css";
+import { queryClient } from "./lib/queryClient";
 import { routes } from "./routes";
 
 const router = createBrowserRouter(routes);
@@ -13,6 +16,9 @@ if (!root) {
 
 createRoot(root).render(
   <StrictMode>
-    <RouterProvider router={router} />
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
   </StrictMode>,
 );


### PR DESCRIPTION
## 概要

TanStack Query v5 を導入し、QueryClient のリトライポリシーを設定する。
リトライの責務を API クライアント層から TanStack Query に一本化した。

## 変更内容

- `@tanstack/react-query` + `@tanstack/react-query-devtools` をインストール
- API クライアント（`lib/api/client.ts`）からリトライロジックを除去
- `lib/queryClient.ts` に QueryClient 設定を追加（リトライ判定関数を分離しテスト可能に）
  - Query: 4xx はリトライしない、5xx/ネットワークエラーは最大 3 回
  - Mutation: リトライなし
- `main.tsx` に `QueryClientProvider` と `ReactQueryDevtools` を追加
- `error-handling.md` のリトライ方針を更新

## 関連 Issue

Closes #240

## テスト

- `shouldRetryQuery` のユニットテスト 7 ケース追加
- API クライアントのリトライ関連テストを削除、既存テストは全て通過
- `npm run check`（Prettier + ESLint + tsc + Vitest + E2E + build）通過

---
🤖 Generated with [Claude Code](https://claude.ai/code)