### PR TITLE
feat(frontend): ボトムナビゲーション・アプリシェルを追加

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tanstack/react-query": "^5.99.0",
         "@tanstack/react-query-devtools": "^5.99.0",
+        "lucide-react": "^1.8.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-router": "^7.14.1",
@@ -3777,6 +3778,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.8.0.tgz",
+      "integrity": "sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@tanstack/react-query": "^5.99.0",
     "@tanstack/react-query-devtools": "^5.99.0",
+    "lucide-react": "^1.8.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router": "^7.14.1",

--- a/frontend/src/components/AppLayout.test.tsx
+++ b/frontend/src/components/AppLayout.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import { createMemoryRouter, RouterProvider } from "react-router";
+import { describe, expect, it } from "vitest";
+
+import { AppLayout } from "./AppLayout";
+
+function renderWithRouter(initialEntry: string) {
+  const router = createMemoryRouter(
+    [
+      {
+        Component: AppLayout,
+        children: [
+          { path: "/transactions", element: <h1>Transactions</h1> },
+          { path: "/analytics", element: <h1>Analytics</h1> },
+        ],
+      },
+    ],
+    { initialEntries: [initialEntry] },
+  );
+  render(<RouterProvider router={router} />);
+  return router;
+}
+
+describe("AppLayout", () => {
+  it("renders child route content", async () => {
+    renderWithRouter("/transactions");
+
+    expect(await screen.findByRole("heading", { name: "Transactions" })).toBeInTheDocument();
+  });
+
+  it("renders bottom navigation", () => {
+    renderWithRouter("/transactions");
+
+    expect(screen.getByRole("link", { name: /transactions/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /analytics/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /settings/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -1,0 +1,12 @@
+import { Outlet } from "react-router";
+
+import { BottomNav } from "./BottomNav";
+
+export function AppLayout() {
+  return (
+    <div className="pb-16">
+      <Outlet />
+      <BottomNav />
+    </div>
+  );
+}

--- a/frontend/src/components/BottomNav.test.tsx
+++ b/frontend/src/components/BottomNav.test.tsx
@@ -8,12 +8,16 @@ function renderWithRouter(initialEntry: string) {
   const router = createMemoryRouter(
     [
       {
+        path: "/transactions",
         element: <BottomNav />,
-        children: [
-          { path: "/transactions", element: <h1>Transactions</h1> },
-          { path: "/analytics", element: <h1>Analytics</h1> },
-          { path: "/settings", element: <h1>Settings</h1> },
-        ],
+      },
+      {
+        path: "/analytics",
+        element: <BottomNav />,
+      },
+      {
+        path: "/settings",
+        element: <BottomNav />,
       },
     ],
     { initialEntries: [initialEntry] },

--- a/frontend/src/components/BottomNav.test.tsx
+++ b/frontend/src/components/BottomNav.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from "@testing-library/react";
+import { createMemoryRouter, RouterProvider } from "react-router";
+import { describe, expect, it } from "vitest";
+
+import { BottomNav } from "./BottomNav";
+
+function renderWithRouter(initialEntry: string) {
+  const router = createMemoryRouter(
+    [
+      {
+        element: <BottomNav />,
+        children: [
+          { path: "/transactions", element: <h1>Transactions</h1> },
+          { path: "/analytics", element: <h1>Analytics</h1> },
+          { path: "/settings", element: <h1>Settings</h1> },
+        ],
+      },
+    ],
+    { initialEntries: [initialEntry] },
+  );
+  render(<RouterProvider router={router} />);
+  return router;
+}
+
+describe("BottomNav", () => {
+  it("renders three navigation links", () => {
+    renderWithRouter("/transactions");
+
+    expect(screen.getByRole("link", { name: /transactions/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /analytics/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /settings/i })).toBeInTheDocument();
+  });
+
+  it("links to correct paths", () => {
+    renderWithRouter("/transactions");
+
+    expect(screen.getByRole("link", { name: /transactions/i })).toHaveAttribute(
+      "href",
+      "/transactions",
+    );
+    expect(screen.getByRole("link", { name: /analytics/i })).toHaveAttribute("href", "/analytics");
+    expect(screen.getByRole("link", { name: /settings/i })).toHaveAttribute("href", "/settings");
+  });
+
+  it("marks current route as active with aria-current", () => {
+    renderWithRouter("/transactions");
+
+    expect(screen.getByRole("link", { name: /transactions/i })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    expect(screen.getByRole("link", { name: /analytics/i })).not.toHaveAttribute("aria-current");
+    expect(screen.getByRole("link", { name: /settings/i })).not.toHaveAttribute("aria-current");
+  });
+
+  it("highlights analytics tab when on analytics route", () => {
+    renderWithRouter("/analytics");
+
+    expect(screen.getByRole("link", { name: /analytics/i })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    expect(screen.getByRole("link", { name: /transactions/i })).not.toHaveAttribute("aria-current");
+  });
+
+  it("highlights settings tab when on settings route", () => {
+    renderWithRouter("/settings");
+
+    expect(screen.getByRole("link", { name: /settings/i })).toHaveAttribute("aria-current", "page");
+    expect(screen.getByRole("link", { name: /transactions/i })).not.toHaveAttribute("aria-current");
+  });
+});

--- a/frontend/src/components/BottomNav.tsx
+++ b/frontend/src/components/BottomNav.tsx
@@ -1,0 +1,32 @@
+import { BarChart3, List, Settings } from "lucide-react";
+import { NavLink } from "react-router";
+
+const tabs = [
+  { to: "/transactions", label: "Transactions", icon: List },
+  { to: "/analytics", label: "Analytics", icon: BarChart3 },
+  { to: "/settings", label: "Settings", icon: Settings },
+] as const;
+
+export function BottomNav() {
+  return (
+    <nav className="fixed inset-x-0 bottom-0 border-t border-gray-200 bg-white">
+      <ul className="flex justify-around">
+        {tabs.map(({ to, label, icon: Icon }) => (
+          <li key={to}>
+            <NavLink
+              to={to}
+              className={({ isActive }) =>
+                `flex flex-col items-center px-3 py-2 text-xs ${
+                  isActive ? "text-blue-600" : "text-gray-500"
+                }`
+              }
+            >
+              <Icon className="h-6 w-6" />
+              {label}
+            </NavLink>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -1,6 +1,7 @@
 import type { RouteObject } from "react-router";
 import { redirect } from "react-router";
 
+import { AppLayout } from "./components/AppLayout";
 import { AuthGuard } from "./components/AuthGuard";
 import AnalyticsPage from "./features/analytics/components/AnalyticsPage";
 import LoginPage from "./features/auth/components/LoginPage";
@@ -16,20 +17,25 @@ export const routes: RouteObject[] = [
     Component: AuthGuard,
     children: [
       {
-        path: "/",
-        loader: () => redirect("/transactions"),
-      },
-      {
-        path: "/transactions",
-        Component: TransactionsPage,
-      },
-      {
-        path: "/analytics",
-        Component: AnalyticsPage,
-      },
-      {
-        path: "/settings",
-        Component: SettingsPage,
+        Component: AppLayout,
+        children: [
+          {
+            path: "/",
+            loader: () => redirect("/transactions"),
+          },
+          {
+            path: "/transactions",
+            Component: TransactionsPage,
+          },
+          {
+            path: "/analytics",
+            Component: AnalyticsPage,
+          },
+          {
+            path: "/settings",
+            Component: SettingsPage,
+          },
+        ],
       },
     ],
   },


### PR DESCRIPTION
## 概要

認証後の全画面で表示するボトムナビゲーション付きレイアウト（アプリシェル）を実装。
モバイルファーストの3タブ構成（Transactions, Analytics, Settings）で、Lucide React アイコンを使用。

## 変更内容

- `lucide-react` パッケージを追加
- `BottomNav` コンポーネント: NavLink ベースの3タブボトムナビ（アクティブルートのハイライト・`aria-current` 自動付与）
- `AppLayout` コンポーネント: `<Outlet />` + `<BottomNav />` のレイアウト
- `routes.tsx`: AuthGuard → AppLayout → ページルートのネスト構造に変更
- 各コンポーネントのユニットテスト（計7テスト）

## 関連 Issue

Closes #241

## テスト

- `npm run check` 全チェック通過（Prettier, ESLint, tsc, Vitest 69テスト, Playwright E2E, ビルド）
- BottomNav: リンク表示・パス・アクティブ状態のテスト（5件）
- AppLayout: 子ルートレンダリング・ナビ表示のテスト（2件）

---
🤖 Generated with [Claude Code](https://claude.ai/code)