### PR TITLE
refactor(frontend): テスト名を規約に統一

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -157,10 +157,11 @@ function TransactionForm() {
 
 ### テストの書き方
 
-- メソッド名は振る舞いを説明する英語で書く
-  - パターン: `<操作や条件>_<期待結果>`
+- テスト名は振る舞いを説明する自然な英語で書く（`it` に続けて英文として読める形）
+  - パターン: `<動詞> <対象> when <条件>`
   - 例: `renders transaction list when data is loaded`
   - 例: `shows error message when API returns 422`
+  - 条件が不要な場合は省略可: `renders three navigation links`
 - Arrange-Act-Assert パターンで構造化し、各セクションを空行で区切る
 - Testing Library の `getByRole`, `getByLabelText` を優先（`getByTestId` は最終手段）
 - API モックは MSW を使用（`src/test/mocks/handlers.ts` にデフォルトハンドラを定義）

--- a/frontend/src/routes.test.tsx
+++ b/frontend/src/routes.test.tsx
@@ -23,28 +23,28 @@ describe("routes", () => {
     mockedGetToken.mockReturnValue(null);
   });
 
-  it("redirects_unauthenticated_user_from_transactions_to_login", async () => {
+  it("redirects unauthenticated user from transactions to login", async () => {
     const router = renderWithRouter("/transactions");
 
     await screen.findByRole("heading", { name: "Login" });
     expect(router.state.location.pathname).toBe("/login");
   });
 
-  it("redirects_unauthenticated_user_from_analytics_to_login", async () => {
+  it("redirects unauthenticated user from analytics to login", async () => {
     const router = renderWithRouter("/analytics");
 
     await screen.findByRole("heading", { name: "Login" });
     expect(router.state.location.pathname).toBe("/login");
   });
 
-  it("redirects_unauthenticated_user_from_settings_to_login", async () => {
+  it("redirects unauthenticated user from settings to login", async () => {
     const router = renderWithRouter("/settings");
 
     await screen.findByRole("heading", { name: "Login" });
     expect(router.state.location.pathname).toBe("/login");
   });
 
-  it("returns_transactions_page_when_authenticated", async () => {
+  it("returns transactions page when authenticated", async () => {
     mockedGetToken.mockReturnValue("valid-token");
 
     renderWithRouter("/transactions");
@@ -52,7 +52,7 @@ describe("routes", () => {
     await screen.findByRole("heading", { name: "Transactions" });
   });
 
-  it("redirects_root_to_transactions", async () => {
+  it("redirects root to transactions", async () => {
     mockedGetToken.mockReturnValue("valid-token");
 
     const router = renderWithRouter("/");
@@ -61,7 +61,7 @@ describe("routes", () => {
     expect(router.state.location.pathname).toBe("/transactions");
   });
 
-  it("returns_login_page_without_authentication", async () => {
+  it("returns login page without authentication", async () => {
     renderWithRouter("/login");
 
     await screen.findByRole("heading", { name: "Login" });


### PR DESCRIPTION
## 概要
frontend のテスト命名規約（自然な英語・スペース区切り）に対し、`routes.test.tsx` のみがスネークケースになっていたため統一した。併せて規約ドキュメントのパターン記述が例文と矛盾していた問題も修正した。

## 変更内容
- `.claude/rules/frontend.md`: テスト名パターン記述をアンダースコア区切りからスペース区切りの自然な英語に修正。条件省略可の例を追加
- `frontend/src/routes.test.tsx`: 6 件のテスト名をスネークケースからスペース区切りに修正

## 関連 Issue
Closes #274

## テスト
- `npm run check` で全チェック通過（Prettier, ESLint, TypeScript, Vitest 69件, E2E, ビルド）

---
🤖 Generated with [Claude Code](https://claude.ai/code)