### PR TITLE
feat(frontend): Google OAuthログイン画面を実装

### DIFF
--- a/frontend/e2e/app.spec.ts
+++ b/frontend/e2e/app.spec.ts
@@ -3,5 +3,5 @@ import { test, expect } from "@playwright/test";
 test("未認証でトップページにアクセスするとログインページにリダイレクトされる", async ({ page }) => {
   await page.goto("/");
   await expect(page).toHaveURL(/\/login/);
-  await expect(page.getByRole("heading", { name: "Login" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Expense Tracker" })).toBeVisible();
 });

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "expense-tracker-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@react-oauth/google": "^0.13.5",
         "@tanstack/react-query": "^5.99.0",
         "@tanstack/react-query-devtools": "^5.99.0",
         "lucide-react": "^1.8.0",
@@ -988,6 +989,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@react-oauth/google": {
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/@react-oauth/google/-/google-0.13.5.tgz",
+      "integrity": "sha512-xQWri2s/3nNekZJ4uuov2aAfQYu83bN3864KcFqw2pK1nNbFurQIjPFDXhWaKH3IjYJ2r/9yyIIpsn5lMqrheQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "check": "prettier --check . && eslint . && tsc -b && vitest run && playwright test && vite build"
   },
   "dependencies": {
+    "@react-oauth/google": "^0.13.5",
     "@tanstack/react-query": "^5.99.0",
     "@tanstack/react-query-devtools": "^5.99.0",
     "lucide-react": "^1.8.0",

--- a/frontend/src/features/auth/api/useGoogleLogin.test.tsx
+++ b/frontend/src/features/auth/api/useGoogleLogin.test.tsx
@@ -16,6 +16,8 @@ vi.mock("react-router", () => ({
 const mockSetToken = vi.fn();
 vi.mock("../../../lib/auth", () => ({
   setToken: (token: string) => mockSetToken(token),
+  clearToken: vi.fn(),
+  getToken: vi.fn(),
 }));
 
 function createWrapper() {

--- a/frontend/src/features/auth/api/useGoogleLogin.test.tsx
+++ b/frontend/src/features/auth/api/useGoogleLogin.test.tsx
@@ -15,7 +15,9 @@ vi.mock("react-router", () => ({
 
 const mockSetToken = vi.fn();
 vi.mock("../../../lib/auth", () => ({
-  setToken: (token: string) => mockSetToken(token),
+  setToken: (token: string): void => {
+    mockSetToken(token);
+  },
   clearToken: vi.fn(),
   getToken: vi.fn(),
 }));
@@ -49,7 +51,9 @@ describe("useGoogleLogin", () => {
 
     result.current.mutate("google-id-token");
 
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
     expect(mockSetToken).toHaveBeenCalledWith("jwt-token-123");
     expect(mockNavigate).toHaveBeenCalledWith("/transactions", { replace: true });
   });
@@ -75,7 +79,9 @@ describe("useGoogleLogin", () => {
 
     result.current.mutate("google-id-token");
 
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
     expect(capturedBody).toEqual({ id_token: "google-id-token" });
   });
 
@@ -98,7 +104,9 @@ describe("useGoogleLogin", () => {
 
     result.current.mutate("invalid-token");
 
-    await waitFor(() => expect(result.current.isError).toBe(true));
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
     expect(result.current.error).toBeInstanceOf(ApiException);
     expect(mockSetToken).not.toHaveBeenCalled();
     expect(mockNavigate).not.toHaveBeenCalled();

--- a/frontend/src/features/auth/api/useGoogleLogin.test.tsx
+++ b/frontend/src/features/auth/api/useGoogleLogin.test.tsx
@@ -1,0 +1,104 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ApiException } from "../../../lib/api/errors";
+import { server } from "../../../test/mocks/server";
+import { useGoogleLogin } from "./useGoogleLogin";
+
+const mockNavigate = vi.fn();
+vi.mock("react-router", () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+const mockSetToken = vi.fn();
+vi.mock("../../../lib/auth", () => ({
+  setToken: (token: string) => mockSetToken(token),
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe("useGoogleLogin", () => {
+  it("returns accessToken and navigates to /transactions on success", async () => {
+    server.use(
+      http.post("/api/v1/auth/google", () => {
+        return HttpResponse.json({
+          access_token: "jwt-token-123",
+          user: {
+            id: 1,
+            email: "test@example.com",
+            display_name: "Test User",
+            created_at: "2026-01-01T00:00:00Z",
+          },
+        });
+      }),
+    );
+
+    const { result } = renderHook(() => useGoogleLogin(), { wrapper: createWrapper() });
+
+    result.current.mutate("google-id-token");
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockSetToken).toHaveBeenCalledWith("jwt-token-123");
+    expect(mockNavigate).toHaveBeenCalledWith("/transactions", { replace: true });
+  });
+
+  it("sends idToken as id_token in request body", async () => {
+    let capturedBody: unknown;
+    server.use(
+      http.post("/api/v1/auth/google", async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json({
+          access_token: "jwt-token-123",
+          user: {
+            id: 1,
+            email: "test@example.com",
+            display_name: "Test User",
+            created_at: "2026-01-01T00:00:00Z",
+          },
+        });
+      }),
+    );
+
+    const { result } = renderHook(() => useGoogleLogin(), { wrapper: createWrapper() });
+
+    result.current.mutate("google-id-token");
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(capturedBody).toEqual({ id_token: "google-id-token" });
+  });
+
+  it("throws ApiException when API returns error", async () => {
+    server.use(
+      http.post("/api/v1/auth/google", () => {
+        return HttpResponse.json(
+          {
+            type: "about:blank",
+            title: "Unauthorized",
+            status: 401,
+            detail: "Invalid ID token",
+          },
+          { status: 401 },
+        );
+      }),
+    );
+
+    const { result } = renderHook(() => useGoogleLogin(), { wrapper: createWrapper() });
+
+    result.current.mutate("invalid-token");
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBeInstanceOf(ApiException);
+    expect(mockSetToken).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/auth/api/useGoogleLogin.ts
+++ b/frontend/src/features/auth/api/useGoogleLogin.ts
@@ -1,0 +1,21 @@
+import { useMutation } from "@tanstack/react-query";
+import { useNavigate } from "react-router";
+
+import { apiClient } from "../../../lib/api/client";
+import { setToken } from "../../../lib/auth";
+import { AuthResponseSchema } from "../../../types/api";
+
+export function useGoogleLogin() {
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: async (idToken: string) => {
+      const data = await apiClient.post("/api/v1/auth/google", { idToken }, { skipAuth: true });
+      return AuthResponseSchema.parse(data);
+    },
+    onSuccess: (data) => {
+      setToken(data.accessToken);
+      navigate("/transactions", { replace: true });
+    },
+  });
+}

--- a/frontend/src/features/auth/api/useGoogleLogin.ts
+++ b/frontend/src/features/auth/api/useGoogleLogin.ts
@@ -15,7 +15,7 @@ export function useGoogleLogin() {
     },
     onSuccess: (data) => {
       setToken(data.accessToken);
-      navigate("/transactions", { replace: true });
+      void navigate("/transactions", { replace: true });
     },
   });
 }

--- a/frontend/src/features/auth/components/LoginPage.test.tsx
+++ b/frontend/src/features/auth/components/LoginPage.test.tsx
@@ -1,0 +1,63 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { createMemoryRouter, RouterProvider } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+
+import { routes } from "../../../routes";
+
+vi.mock("../../../lib/auth", () => ({
+  getToken: vi.fn(),
+  setToken: vi.fn(),
+  clearToken: vi.fn(),
+}));
+
+const { getToken } = await import("../../../lib/auth");
+const mockGetToken = vi.mocked(getToken);
+
+vi.mock("@react-oauth/google", () => ({
+  GoogleLogin: (props: { onSuccess: unknown; onError: unknown }) => (
+    <button data-testid="google-login-button" type="button">
+      Sign in with Google
+    </button>
+  ),
+  GoogleOAuthProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+function renderLoginPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  });
+  const router = createMemoryRouter(routes, { initialEntries: ["/login"] });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  );
+}
+
+describe("LoginPage", () => {
+  it("renders app name", () => {
+    mockGetToken.mockReturnValue(null);
+
+    renderLoginPage();
+
+    expect(screen.getByText("Expense Tracker")).toBeInTheDocument();
+  });
+
+  it("renders Google login button", () => {
+    mockGetToken.mockReturnValue(null);
+
+    renderLoginPage();
+
+    expect(screen.getByTestId("google-login-button")).toBeInTheDocument();
+  });
+
+  it("redirects to /transactions when already authenticated", async () => {
+    mockGetToken.mockReturnValue("existing-jwt-token");
+
+    renderLoginPage();
+
+    expect(screen.queryByText("Expense Tracker")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/auth/components/LoginPage.test.tsx
+++ b/frontend/src/features/auth/components/LoginPage.test.tsx
@@ -16,7 +16,7 @@ const { getToken } = await import("../../../lib/auth");
 const mockGetToken = vi.mocked(getToken);
 
 vi.mock("@react-oauth/google", () => ({
-  GoogleLogin: (props: { onSuccess: unknown; onError: unknown }) => (
+  GoogleLogin: () => (
     <button data-testid="google-login-button" type="button">
       Sign in with Google
     </button>
@@ -53,7 +53,7 @@ describe("LoginPage", () => {
     expect(screen.getByTestId("google-login-button")).toBeInTheDocument();
   });
 
-  it("redirects to /transactions when already authenticated", async () => {
+  it("redirects to /transactions when already authenticated", () => {
     mockGetToken.mockReturnValue("existing-jwt-token");
 
     renderLoginPage();

--- a/frontend/src/features/auth/components/LoginPage.tsx
+++ b/frontend/src/features/auth/components/LoginPage.tsx
@@ -1,3 +1,53 @@
+import { GoogleLogin } from "@react-oauth/google";
+import { useState } from "react";
+import { Navigate } from "react-router";
+
+import { getToken } from "../../../lib/auth";
+import { useGoogleLogin } from "../api/useGoogleLogin";
+
 export default function LoginPage() {
-  return <h1>Login</h1>;
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const googleLogin = useGoogleLogin();
+
+  if (getToken()) {
+    return <Navigate to="/transactions" replace />;
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
+      <div className="w-full max-w-sm text-center">
+        <h1 className="mb-8 text-3xl font-bold text-gray-900">Expense Tracker</h1>
+
+        <div className="flex justify-center">
+          <GoogleLogin
+            onSuccess={(response) => {
+              if (response.credential) {
+                setErrorMessage(null);
+                googleLogin.mutate(response.credential);
+              }
+            }}
+            onError={() => {
+              setErrorMessage("Google認証に失敗しました。もう一度お試しください。");
+            }}
+            size="large"
+            text="signin_with"
+            shape="rectangular"
+            width="300"
+          />
+        </div>
+
+        {errorMessage && (
+          <p role="alert" className="mt-4 text-sm text-red-600">
+            {errorMessage}
+          </p>
+        )}
+
+        {googleLogin.isError && (
+          <p role="alert" className="mt-4 text-sm text-red-600">
+            ログインに失敗しました。もう一度お試しください。
+          </p>
+        )}
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -26,6 +26,7 @@ interface RequestOptions {
   skipAuth?: boolean;
 }
 
+// TODO: feature 層実装時に戻り値型をジェネリクス化するか、呼び出し側で Zod parse するか方針を決定する
 async function request(
   method: string,
   path: string,

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -17,7 +17,7 @@ if (!root) {
 
 createRoot(root).render(
   <StrictMode>
-    <GoogleOAuthProvider clientId={import.meta.env.VITE_GOOGLE_CLIENT_ID}>
+    <GoogleOAuthProvider clientId={String(import.meta.env.VITE_GOOGLE_CLIENT_ID ?? "")}>
       <QueryClientProvider client={queryClient}>
         <RouterProvider router={router} />
         <ReactQueryDevtools initialIsOpen={false} />

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,3 +1,4 @@
+import { GoogleOAuthProvider } from "@react-oauth/google";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { StrictMode } from "react";
@@ -16,9 +17,11 @@ if (!root) {
 
 createRoot(root).render(
   <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
-      <ReactQueryDevtools initialIsOpen={false} />
-    </QueryClientProvider>
+    <GoogleOAuthProvider clientId={import.meta.env.VITE_GOOGLE_CLIENT_ID}>
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+        <ReactQueryDevtools initialIsOpen={false} />
+      </QueryClientProvider>
+    </GoogleOAuthProvider>
   </StrictMode>,
 );

--- a/frontend/src/routes.test.tsx
+++ b/frontend/src/routes.test.tsx
@@ -1,4 +1,6 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { createMemoryRouter, RouterProvider } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -6,15 +8,33 @@ import { routes } from "./routes";
 
 vi.mock("./lib/auth", () => ({
   getToken: vi.fn(),
+  setToken: vi.fn(),
+  clearToken: vi.fn(),
 }));
 
 import { getToken } from "./lib/auth";
 
 const mockedGetToken = vi.mocked(getToken);
 
+vi.mock("@react-oauth/google", () => ({
+  GoogleLogin: () => (
+    <button data-testid="google-login-button" type="button">
+      Sign in with Google
+    </button>
+  ),
+  GoogleOAuthProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
 function renderWithRouter(initialEntry: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  });
   const router = createMemoryRouter(routes, { initialEntries: [initialEntry] });
-  render(<RouterProvider router={router} />);
+  render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  );
   return router;
 }
 
@@ -26,21 +46,21 @@ describe("routes", () => {
   it("redirects unauthenticated user from transactions to login", async () => {
     const router = renderWithRouter("/transactions");
 
-    await screen.findByRole("heading", { name: "Login" });
+    await screen.findByText("Expense Tracker");
     expect(router.state.location.pathname).toBe("/login");
   });
 
   it("redirects unauthenticated user from analytics to login", async () => {
     const router = renderWithRouter("/analytics");
 
-    await screen.findByRole("heading", { name: "Login" });
+    await screen.findByText("Expense Tracker");
     expect(router.state.location.pathname).toBe("/login");
   });
 
   it("redirects unauthenticated user from settings to login", async () => {
     const router = renderWithRouter("/settings");
 
-    await screen.findByRole("heading", { name: "Login" });
+    await screen.findByText("Expense Tracker");
     expect(router.state.location.pathname).toBe("/login");
   });
 
@@ -61,9 +81,9 @@ describe("routes", () => {
     expect(router.state.location.pathname).toBe("/transactions");
   });
 
-  it("returns login page without authentication", async () => {
+  it("renders login page without authentication", async () => {
     renderWithRouter("/login");
 
-    await screen.findByRole("heading", { name: "Login" });
+    await screen.findByText("Expense Tracker");
   });
 });

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -1,3 +1,17 @@
+import { http, HttpResponse } from "msw";
+
 import type { HttpHandler } from "msw";
 
-export const handlers: HttpHandler[] = [];
+export const handlers: HttpHandler[] = [
+  http.post("/api/v1/auth/google", () => {
+    return HttpResponse.json({
+      access_token: "mock-jwt-token",
+      user: {
+        id: 1,
+        email: "test@example.com",
+        display_name: "Test User",
+        created_at: "2026-01-01T00:00:00Z",
+      },
+    });
+  }),
+];

--- a/frontend/src/types/api.test.ts
+++ b/frontend/src/types/api.test.ts
@@ -65,8 +65,8 @@ describe("AuthResponseSchema", () => {
 });
 
 describe("GoogleAuthRequestSchema", () => {
-  it("validates id_token field", () => {
-    const input = { id_token: "google-id-token" };
+  it("validates idToken field", () => {
+    const input = { idToken: "google-id-token" };
 
     const result = GoogleAuthRequestSchema.parse(input);
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -48,13 +48,9 @@ export type AuthResponse = z.infer<typeof AuthResponseSchema>;
 // ------------------------------------------------------------
 
 /** Google 認証リクエスト（POST /api/v1/auth/google） */
-export const GoogleAuthRequestSchema = z
-  .object({
-    id_token: z.string(),
-  })
-  .transform(({ id_token }) => ({
-    idToken: id_token,
-  }));
+export const GoogleAuthRequestSchema = z.object({
+  idToken: z.string(),
+});
 export type GoogleAuthRequest = z.infer<typeof GoogleAuthRequestSchema>;
 
 // ------------------------------------------------------------


### PR DESCRIPTION
## 概要

Google OAuth2 によるログイン画面を実装。`@react-oauth/google` を使って ID トークンを取得し、バックエンドに送信して JWT を受け取りインメモリに保存する。

## 変更内容

- `@react-oauth/google` パッケージを追加
- `useGoogleLogin` フック（`useMutation` で `POST /api/v1/auth/google` を呼び出し）を実装
- `LoginPage` を Google ログインボタン・エラー表示・既認証リダイレクト付きで実装
- `main.tsx` に `GoogleOAuthProvider` を追加
- MSW に `POST /api/v1/auth/google` のデフォルトハンドラを追加
- `GoogleAuthRequestSchema` を camelCase に統一
- `apiClient` の戻り値型に TODO コメントを追加
- 既存テスト（`routes.test.tsx`、E2E）を LoginPage の変更に合わせて更新

## 関連 Issue

Closes #242

## テスト

- `npm run check`（Prettier + ESLint + tsc + Vitest + Playwright + build）全通過
- useGoogleLogin: 認証成功時のトークン保存・リダイレクト、リクエストボディ形式、APIエラー時の検証
- LoginPage: アプリ名表示、Google ログインボタン表示、既認証時リダイレクト
- E2E: 未認証時のログインページリダイレクト確認

---
🤖 Generated with [Claude Code](https://claude.ai/code)