### PR TITLE
feat: 期間セレクタコンポーネントを追加

### DIFF
--- a/frontend/src/components/PeriodSelector.test.tsx
+++ b/frontend/src/components/PeriodSelector.test.tsx
@@ -8,7 +8,7 @@ type Period = { from: string; to: string } | null;
 
 describe("PeriodSelector", () => {
   beforeEach(() => {
-    vi.useFakeTimers();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
     vi.setSystemTime(new Date("2026-02-15T12:00:00Z"));
   });
 

--- a/frontend/src/components/PeriodSelector.test.tsx
+++ b/frontend/src/components/PeriodSelector.test.tsx
@@ -2,9 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { PeriodSelector } from "./PeriodSelector";
-
-type Period = { from: string; to: string } | null;
+import { PeriodSelector, type Period } from "./PeriodSelector";
 
 describe("PeriodSelector", () => {
   beforeEach(() => {

--- a/frontend/src/components/PeriodSelector.test.tsx
+++ b/frontend/src/components/PeriodSelector.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { PeriodSelector } from "./PeriodSelector";
+
+type Period = { from: string; to: string } | null;
+
+describe("PeriodSelector", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-15T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders the current month label by default", () => {
+    render(<PeriodSelector onChange={vi.fn()} />);
+
+    expect(screen.getByText("February 2026")).toBeInTheDocument();
+  });
+
+  it("notifies the current month range on mount", () => {
+    const onChange = vi.fn<(period: Period) => void>();
+
+    render(<PeriodSelector onChange={onChange} />);
+
+    expect(onChange).toHaveBeenCalledWith({ from: "2026-02-01", to: "2026-02-28" });
+  });
+
+  it("navigates to the previous month when the previous button is clicked", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const onChange = vi.fn<(period: Period) => void>();
+    render(<PeriodSelector onChange={onChange} />);
+
+    await user.click(screen.getByRole("button", { name: /previous period/i }));
+
+    expect(screen.getByText("January 2026")).toBeInTheDocument();
+    expect(onChange).toHaveBeenLastCalledWith({ from: "2026-01-01", to: "2026-01-31" });
+  });
+
+  it("navigates to the next month when the next button is clicked", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const onChange = vi.fn<(period: Period) => void>();
+    render(<PeriodSelector onChange={onChange} />);
+
+    await user.click(screen.getByRole("button", { name: /next period/i }));
+
+    expect(screen.getByText("March 2026")).toBeInTheDocument();
+    expect(onChange).toHaveBeenLastCalledWith({ from: "2026-03-01", to: "2026-03-31" });
+  });
+
+  it("wraps to December of the previous year when going back from January", async () => {
+    vi.setSystemTime(new Date("2026-01-10T12:00:00Z"));
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const onChange = vi.fn<(period: Period) => void>();
+    render(<PeriodSelector onChange={onChange} />);
+
+    await user.click(screen.getByRole("button", { name: /previous period/i }));
+
+    expect(screen.getByText("December 2025")).toBeInTheDocument();
+    expect(onChange).toHaveBeenLastCalledWith({ from: "2025-12-01", to: "2025-12-31" });
+  });
+
+  it("computes the last day of February in a leap year", () => {
+    vi.setSystemTime(new Date("2024-02-15T12:00:00Z"));
+    const onChange = vi.fn<(period: Period) => void>();
+
+    render(<PeriodSelector onChange={onChange} />);
+
+    expect(onChange).toHaveBeenCalledWith({ from: "2024-02-01", to: "2024-02-29" });
+  });
+
+  it("switches to the year view with the current year when Year is selected", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const onChange = vi.fn<(period: Period) => void>();
+    render(<PeriodSelector onChange={onChange} />);
+
+    await user.click(screen.getByRole("button", { name: /^year$/i }));
+
+    expect(screen.getByText("2026")).toBeInTheDocument();
+    expect(onChange).toHaveBeenLastCalledWith({ from: "2026-01-01", to: "2026-12-31" });
+  });
+
+  it("navigates to the previous year when in year view", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const onChange = vi.fn<(period: Period) => void>();
+    render(<PeriodSelector onChange={onChange} />);
+
+    await user.click(screen.getByRole("button", { name: /^year$/i }));
+    await user.click(screen.getByRole("button", { name: /previous period/i }));
+
+    expect(screen.getByText("2025")).toBeInTheDocument();
+    expect(onChange).toHaveBeenLastCalledWith({ from: "2025-01-01", to: "2025-12-31" });
+  });
+
+  it("navigates to the next year when in year view", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const onChange = vi.fn<(period: Period) => void>();
+    render(<PeriodSelector onChange={onChange} />);
+
+    await user.click(screen.getByRole("button", { name: /^year$/i }));
+    await user.click(screen.getByRole("button", { name: /next period/i }));
+
+    expect(screen.getByText("2027")).toBeInTheDocument();
+    expect(onChange).toHaveBeenLastCalledWith({ from: "2027-01-01", to: "2027-12-31" });
+  });
+
+  it("shows 'All Transactions' and notifies null when All is selected", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const onChange = vi.fn<(period: Period) => void>();
+    render(<PeriodSelector onChange={onChange} />);
+
+    await user.click(screen.getByRole("button", { name: /^all$/i }));
+
+    expect(screen.getByText("All Transactions")).toBeInTheDocument();
+    expect(onChange).toHaveBeenLastCalledWith(null);
+  });
+
+  it("hides previous and next buttons when All is selected", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<PeriodSelector onChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("button", { name: /^all$/i }));
+
+    expect(screen.queryByRole("button", { name: /previous period/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /next period/i })).not.toBeInTheDocument();
+  });
+
+  it("restores the month view with the current month when switching back from All", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const onChange = vi.fn<(period: Period) => void>();
+    render(<PeriodSelector onChange={onChange} />);
+
+    await user.click(screen.getByRole("button", { name: /^all$/i }));
+    await user.click(screen.getByRole("button", { name: /^month$/i }));
+
+    expect(screen.getByText("February 2026")).toBeInTheDocument();
+    expect(onChange).toHaveBeenLastCalledWith({ from: "2026-02-01", to: "2026-02-28" });
+  });
+});

--- a/frontend/src/components/PeriodSelector.tsx
+++ b/frontend/src/components/PeriodSelector.tsx
@@ -1,23 +1,17 @@
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
+import { type IsoDate, toIsoDate } from "../lib/isoDate";
+
 type Unit = "month" | "year" | "all";
 
-export type Period = { from: string; to: string } | null;
+export type Period = { from: IsoDate; to: IsoDate } | null;
 
 interface PeriodSelectorProps {
   onChange: (period: Period) => void;
 }
 
 const MONTH_FORMATTER = new Intl.DateTimeFormat("en-US", { month: "long", year: "numeric" });
-
-function pad2(n: number) {
-  return n.toString().padStart(2, "0");
-}
-
-function formatDate(year: number, month: number, day: number): string {
-  return `${year.toString().padStart(4, "0")}-${pad2(month)}-${pad2(day)}`;
-}
 
 function lastDayOfMonth(year: number, month: number): number {
   return new Date(year, month, 0).getDate();
@@ -27,12 +21,12 @@ function computePeriod(unit: Unit, anchor: Date): Period {
   if (unit === "all") return null;
   const year = anchor.getFullYear();
   if (unit === "year") {
-    return { from: formatDate(year, 1, 1), to: formatDate(year, 12, 31) };
+    return { from: toIsoDate(year, 1, 1), to: toIsoDate(year, 12, 31) };
   }
   const month = anchor.getMonth() + 1;
   return {
-    from: formatDate(year, month, 1),
-    to: formatDate(year, month, lastDayOfMonth(year, month)),
+    from: toIsoDate(year, month, 1),
+    to: toIsoDate(year, month, lastDayOfMonth(year, month)),
   };
 }
 

--- a/frontend/src/components/PeriodSelector.tsx
+++ b/frontend/src/components/PeriodSelector.tsx
@@ -1,10 +1,128 @@
-type Period = { from: string; to: string } | null;
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+type Unit = "month" | "year" | "all";
+
+export type Period = { from: string; to: string } | null;
 
 interface PeriodSelectorProps {
   onChange: (period: Period) => void;
 }
 
-export function PeriodSelector(props: PeriodSelectorProps) {
-  void props;
-  return null;
+const MONTH_FORMATTER = new Intl.DateTimeFormat("en-US", { month: "long", year: "numeric" });
+
+function pad2(n: number) {
+  return n.toString().padStart(2, "0");
+}
+
+function formatDate(year: number, month: number, day: number): string {
+  return `${year.toString().padStart(4, "0")}-${pad2(month)}-${pad2(day)}`;
+}
+
+function lastDayOfMonth(year: number, month: number): number {
+  return new Date(year, month, 0).getDate();
+}
+
+function computePeriod(unit: Unit, anchor: Date): Period {
+  if (unit === "all") return null;
+  const year = anchor.getFullYear();
+  if (unit === "year") {
+    return { from: formatDate(year, 1, 1), to: formatDate(year, 12, 31) };
+  }
+  const month = anchor.getMonth() + 1;
+  return {
+    from: formatDate(year, month, 1),
+    to: formatDate(year, month, lastDayOfMonth(year, month)),
+  };
+}
+
+function formatLabel(unit: Unit, anchor: Date): string {
+  if (unit === "all") return "All Transactions";
+  if (unit === "year") return anchor.getFullYear().toString();
+  return MONTH_FORMATTER.format(anchor);
+}
+
+function shiftAnchor(unit: Unit, anchor: Date, direction: -1 | 1): Date {
+  const next = new Date(anchor);
+  next.setDate(1);
+  if (unit === "year") {
+    next.setFullYear(next.getFullYear() + direction);
+  } else {
+    next.setMonth(next.getMonth() + direction);
+  }
+  return next;
+}
+
+export function PeriodSelector({ onChange }: PeriodSelectorProps) {
+  const [unit, setUnit] = useState<Unit>("month");
+  const [anchor, setAnchor] = useState<Date>(() => new Date());
+
+  const onChangeRef = useRef(onChange);
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+
+  useEffect(() => {
+    onChangeRef.current(computePeriod(unit, anchor));
+  }, [unit, anchor]);
+
+  const handleUnitChange = (nextUnit: Unit) => {
+    if (nextUnit === unit) return;
+    setUnit(nextUnit);
+    // 単位切替時は現在日時にリセット（「All → Month」で当月が戻るため）
+    setAnchor(new Date());
+  };
+
+  const showNav = unit !== "all";
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-center gap-2">
+        {showNav && (
+          <button
+            type="button"
+            aria-label="Previous period"
+            onClick={() => {
+              setAnchor((prev) => shiftAnchor(unit, prev, -1));
+            }}
+            className="inline-flex h-8 w-8 items-center justify-center rounded text-gray-600 hover:bg-gray-100"
+          >
+            <ChevronLeft className="h-5 w-5" />
+          </button>
+        )}
+        <span className="min-w-40 text-center text-base font-medium">
+          {formatLabel(unit, anchor)}
+        </span>
+        {showNav && (
+          <button
+            type="button"
+            aria-label="Next period"
+            onClick={() => {
+              setAnchor((prev) => shiftAnchor(unit, prev, 1));
+            }}
+            className="inline-flex h-8 w-8 items-center justify-center rounded text-gray-600 hover:bg-gray-100"
+          >
+            <ChevronRight className="h-5 w-5" />
+          </button>
+        )}
+      </div>
+      <div role="group" className="flex justify-center gap-1 text-sm">
+        {(["month", "year", "all"] as const).map((u) => (
+          <button
+            key={u}
+            type="button"
+            aria-pressed={unit === u}
+            onClick={() => {
+              handleUnitChange(u);
+            }}
+            className={`rounded px-3 py-1 ${
+              unit === u ? "bg-blue-600 text-white" : "bg-gray-100 text-gray-700"
+            }`}
+          >
+            {u === "month" ? "Month" : u === "year" ? "Year" : "All"}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/components/PeriodSelector.tsx
+++ b/frontend/src/components/PeriodSelector.tsx
@@ -1,0 +1,10 @@
+type Period = { from: string; to: string } | null;
+
+interface PeriodSelectorProps {
+  onChange: (period: Period) => void;
+}
+
+export function PeriodSelector(props: PeriodSelectorProps) {
+  void props;
+  return null;
+}

--- a/frontend/src/lib/isoDate.test.ts
+++ b/frontend/src/lib/isoDate.test.ts
@@ -14,4 +14,41 @@ describe("toIsoDate", () => {
   it("pads year to four digits", () => {
     expect(toIsoDate(42, 12, 31)).toBe("0042-12-31");
   });
+
+  it("accepts February 29 in a leap year", () => {
+    expect(toIsoDate(2024, 2, 29)).toBe("2024-02-29");
+  });
+
+  it.each([
+    ["month below range", 2026, 0, 15],
+    ["month above range", 2026, 13, 15],
+    ["day below range", 2026, 1, 0],
+    ["day above range", 2026, 1, 32],
+  ])("throws RangeError when %s", (_label, year, month, day) => {
+    expect(() => toIsoDate(year, month, day)).toThrow(RangeError);
+  });
+
+  it("throws RangeError when the date does not exist in the month", () => {
+    expect(() => toIsoDate(2026, 2, 30)).toThrow(RangeError);
+  });
+
+  it("throws RangeError when February 29 is given in a non-leap year", () => {
+    expect(() => toIsoDate(2025, 2, 29)).toThrow(RangeError);
+  });
+
+  it.each([
+    ["year below range", 0, 1, 1],
+    ["year above range", 10000, 1, 1],
+    ["negative year", -1, 1, 1],
+  ])("throws RangeError when %s", (_label, year, month, day) => {
+    expect(() => toIsoDate(year, month, day)).toThrow(RangeError);
+  });
+
+  it.each([
+    ["year is not an integer", 2026.5, 1, 1],
+    ["month is not an integer", 2026, 1.5, 1],
+    ["day is not an integer", 2026, 1, 1.5],
+  ])("throws RangeError when %s", (_label, year, month, day) => {
+    expect(() => toIsoDate(year, month, day)).toThrow(RangeError);
+  });
 });

--- a/frontend/src/lib/isoDate.test.ts
+++ b/frontend/src/lib/isoDate.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { toIsoDate } from "./isoDate";
+
+describe("toIsoDate", () => {
+  it("returns a date string in YYYY-MM-DD format", () => {
+    expect(toIsoDate(2026, 2, 15)).toBe("2026-02-15");
+  });
+
+  it("pads single-digit month and day with a leading zero", () => {
+    expect(toIsoDate(2026, 1, 5)).toBe("2026-01-05");
+  });
+
+  it("pads year to four digits", () => {
+    expect(toIsoDate(42, 12, 31)).toBe("0042-12-31");
+  });
+});

--- a/frontend/src/lib/isoDate.test.ts
+++ b/frontend/src/lib/isoDate.test.ts
@@ -22,8 +22,10 @@ describe("toIsoDate", () => {
   it.each([
     ["month below range", 2026, 0, 15],
     ["month above range", 2026, 13, 15],
+    ["negative month", 2026, -1, 15],
     ["day below range", 2026, 1, 0],
     ["day above range", 2026, 1, 32],
+    ["negative day", 2026, 1, -1],
   ])("throws RangeError when %s", (_label, year, month, day) => {
     expect(() => toIsoDate(year, month, day)).toThrow(RangeError);
   });

--- a/frontend/src/lib/isoDate.ts
+++ b/frontend/src/lib/isoDate.ts
@@ -1,0 +1,18 @@
+/**
+ * YYYY-MM-DD 形式の日付文字列を表す Branded Type。
+ *
+ * `toIsoDate` 経由でのみ生成可能にすることでフォーマット不正を型で排除する。
+ * ランタイムには単なる string であり、追加のオーバーヘッドはない。
+ */
+export type IsoDate = string & { readonly __brand: "IsoDate" };
+
+function pad2(n: number): string {
+  return n.toString().padStart(2, "0");
+}
+
+export function toIsoDate(year: number, month: number, day: number): IsoDate {
+  const value = `${year.toString().padStart(4, "0")}-${pad2(month)}-${pad2(day)}`;
+  // Branded Type を生成する唯一の入口。ここのみ型アサーションを許容する。
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  return value as IsoDate;
+}

--- a/frontend/src/lib/isoDate.ts
+++ b/frontend/src/lib/isoDate.ts
@@ -11,6 +11,27 @@ function pad2(n: number): string {
 }
 
 export function toIsoDate(year: number, month: number, day: number): IsoDate {
+  if (!Number.isInteger(year) || !Number.isInteger(month) || !Number.isInteger(day)) {
+    throw new RangeError(
+      `toIsoDate: year/month/day must be integers (got ${year.toString()}/${month.toString()}/${day.toString()})`,
+    );
+  }
+  // YYYY-MM-DD（4 桁年）として表現可能な範囲に限定する。
+  if (year < 1 || year > 9999) {
+    throw new RangeError(`toIsoDate: year must be in 1..9999 (got ${year.toString()})`);
+  }
+  // Date コンストラクタは 0-99 年を 1900+year に変換するため、setUTCFullYear で明示的に設定する。
+  const date = new Date(0);
+  date.setUTCFullYear(year, month - 1, day);
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) {
+    throw new RangeError(
+      `toIsoDate: invalid date ${year.toString()}-${month.toString()}-${day.toString()}`,
+    );
+  }
   const value = `${year.toString().padStart(4, "0")}-${pad2(month)}-${pad2(day)}`;
   // Branded Type を生成する唯一の入口。ここのみ型アサーションを許容する。
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions


### PR DESCRIPTION
## 概要
支出一覧画面・分析画面で共用する期間セレクタコンポーネントを追加する。月/年/すべての表示単位切替と ◀▶ ナビゲーションを備え、`onChange` で ISO 8601 形式の `{ from, to }` または `null`（すべて）を通知する。

## 変更内容
- `PeriodSelector` コンポーネントを新規追加（`src/components/PeriodSelector.tsx`）
  - 表示単位: 月（`February 2026`）/ 年（`2026`）/ すべて（`All Transactions`）
  - ◀▶ ボタンで前後期間へ遷移（月跨ぎ・年跨ぎ・閏年末日を考慮）
  - すべて表示時は ◀▶ を非表示、`onChange` に `null` を通知
  - デフォルトは月表示・当月
- 振る舞いベースのユニットテスト 12 件を追加
  - 表示ラベル、初期 `onChange`、前後ナビゲーション、単位切替、1 月→前月で前年 12 月に遡及、閏年 2 月の末日計算（2024-02-29）、`All` 時のボタン非表示、`All → Month` 切替で当月に戻る挙動

## 関連 Issue
Closes #245

## テスト
- [x] `npm run check`（Prettier + ESLint + tsc + Vitest 107件 + Playwright + build）すべて通過
- [ ] 実画面（支出一覧・分析）への組み込みは後続 Issue で行う

---
🤖 Generated with [Claude Code](https://claude.ai/code)