### PR TITLE
feat: 通貨管理フック useCurrency を追加

### DIFF
--- a/frontend/src/hooks/useCurrency.test.ts
+++ b/frontend/src/hooks/useCurrency.test.ts
@@ -1,0 +1,88 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useCurrency } from "@/hooks/useCurrency";
+
+const STORAGE_KEY = "expense-tracker:currency";
+
+describe("useCurrency", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns currency detected from navigator.language when localStorage is empty", () => {
+    vi.spyOn(navigator, "language", "get").mockReturnValue("ja-JP");
+
+    const { result } = renderHook(() => useCurrency());
+
+    expect(result.current.currency).toBe("JPY");
+  });
+
+  it("returns persisted currency when localStorage has a value", () => {
+    localStorage.setItem(STORAGE_KEY, "EUR");
+
+    const { result } = renderHook(() => useCurrency());
+
+    expect(result.current.currency).toBe("EUR");
+  });
+
+  it("persists currency to localStorage when setCurrency is called", () => {
+    const { result } = renderHook(() => useCurrency());
+
+    act(() => {
+      result.current.setCurrency("GBP");
+    });
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("GBP");
+    expect(result.current.currency).toBe("GBP");
+  });
+
+  it("syncs currency across hook instances when setCurrency is called", () => {
+    const { result: first } = renderHook(() => useCurrency());
+    const { result: second } = renderHook(() => useCurrency());
+
+    act(() => {
+      first.current.setCurrency("GBP");
+    });
+
+    expect(second.current.currency).toBe("GBP");
+  });
+
+  it("formats amount as JPY without decimal places", () => {
+    localStorage.setItem(STORAGE_KEY, "JPY");
+    vi.spyOn(navigator, "language", "get").mockReturnValue("en-US");
+
+    const { result } = renderHook(() => useCurrency());
+
+    expect(result.current.formatAmount(1200)).toBe("¥1,200");
+  });
+
+  it("formats amount as USD with two decimal places", () => {
+    localStorage.setItem(STORAGE_KEY, "USD");
+    vi.spyOn(navigator, "language", "get").mockReturnValue("en-US");
+
+    const { result } = renderHook(() => useCurrency());
+
+    expect(result.current.formatAmount(12)).toBe("$12.00");
+  });
+
+  it("exposes 0 decimal digits for JPY", () => {
+    localStorage.setItem(STORAGE_KEY, "JPY");
+
+    const { result } = renderHook(() => useCurrency());
+
+    expect(result.current.decimalDigits).toBe(0);
+  });
+
+  it("exposes 2 decimal digits for USD", () => {
+    localStorage.setItem(STORAGE_KEY, "USD");
+
+    const { result } = renderHook(() => useCurrency());
+
+    expect(result.current.decimalDigits).toBe(2);
+  });
+});

--- a/frontend/src/hooks/useCurrency.ts
+++ b/frontend/src/hooks/useCurrency.ts
@@ -1,0 +1,56 @@
+import { useCallback, useMemo, useSyncExternalStore } from "react";
+
+import { detectCurrencyFromLocale, formatCurrency, getCurrencyDecimalDigits } from "@/lib/currency";
+
+const STORAGE_KEY = "expense-tracker:currency";
+
+const listeners = new Set<() => void>();
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  const handleStorage = (event: StorageEvent) => {
+    if (event.key === STORAGE_KEY) {
+      listener();
+    }
+  };
+  window.addEventListener("storage", handleStorage);
+  return () => {
+    listeners.delete(listener);
+    window.removeEventListener("storage", handleStorage);
+  };
+}
+
+function getSnapshot(): string {
+  return localStorage.getItem(STORAGE_KEY) ?? detectCurrencyFromLocale(navigator.language);
+}
+
+function getServerSnapshot(): string {
+  return "USD";
+}
+
+interface UseCurrencyReturn {
+  currency: string;
+  setCurrency: (code: string) => void;
+  formatAmount: (amount: number) => string;
+  decimalDigits: number;
+}
+
+export function useCurrency(): UseCurrencyReturn {
+  const currency = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+  const setCurrency = useCallback((code: string) => {
+    localStorage.setItem(STORAGE_KEY, code);
+    listeners.forEach((listener) => {
+      listener();
+    });
+  }, []);
+
+  const formatAmount = useCallback(
+    (amount: number) => formatCurrency(amount, currency),
+    [currency],
+  );
+
+  const decimalDigits = useMemo(() => getCurrencyDecimalDigits(currency), [currency]);
+
+  return { currency, setCurrency, formatAmount, decimalDigits };
+}

--- a/frontend/src/lib/currency.test.ts
+++ b/frontend/src/lib/currency.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { detectCurrencyFromLocale, formatCurrency, getCurrencyDecimalDigits } from "./currency";
+
+describe("detectCurrencyFromLocale", () => {
+  it.each([
+    ["ja-JP", "JPY"],
+    ["en-US", "USD"],
+    ["en-GB", "GBP"],
+    ["de-DE", "EUR"],
+    ["fr-FR", "EUR"],
+    ["ko-KR", "KRW"],
+    ["zh-CN", "CNY"],
+  ])("returns %s currency for locale %s", (locale, expected) => {
+    expect(detectCurrencyFromLocale(locale)).toBe(expected);
+  });
+
+  it("returns USD when locale region is unknown", () => {
+    expect(detectCurrencyFromLocale("xx-ZZ")).toBe("USD");
+  });
+
+  it("returns USD when locale string is invalid", () => {
+    expect(detectCurrencyFromLocale("not-a-locale!!")).toBe("USD");
+  });
+
+  it("returns USD when locale has no region subtag", () => {
+    expect(detectCurrencyFromLocale("en")).toBe("USD");
+  });
+});
+
+describe("getCurrencyDecimalDigits", () => {
+  it("returns 0 for JPY", () => {
+    expect(getCurrencyDecimalDigits("JPY")).toBe(0);
+  });
+
+  it("returns 2 for USD", () => {
+    expect(getCurrencyDecimalDigits("USD")).toBe(2);
+  });
+
+  it("returns 2 for EUR", () => {
+    expect(getCurrencyDecimalDigits("EUR")).toBe(2);
+  });
+
+  it("returns 0 for KRW", () => {
+    expect(getCurrencyDecimalDigits("KRW")).toBe(0);
+  });
+});
+
+describe("formatCurrency", () => {
+  it("formats JPY without decimal places", () => {
+    expect(formatCurrency(1200, "JPY", "en-US")).toBe("¥1,200");
+  });
+
+  it("formats USD with two decimal places", () => {
+    expect(formatCurrency(12, "USD", "en-US")).toBe("$12.00");
+  });
+
+  it("formats USD rounding to two decimal places", () => {
+    expect(formatCurrency(12.5, "USD", "en-US")).toBe("$12.50");
+  });
+});

--- a/frontend/src/lib/currency.ts
+++ b/frontend/src/lib/currency.ts
@@ -1,0 +1,67 @@
+/**
+ * 通貨コード（ISO 4217）に関する純粋ユーティリティ。
+ *
+ * 通貨設定はフロントエンドで管理する（バックエンドは金額の数値のみ扱う）。
+ * @see docs/03-design/backend/domain-model.md
+ */
+
+const REGION_TO_CURRENCY: Record<string, string> = {
+  JP: "JPY",
+  US: "USD",
+  GB: "GBP",
+  AU: "AUD",
+  CA: "CAD",
+  KR: "KRW",
+  CN: "CNY",
+  TW: "TWD",
+  HK: "HKD",
+  SG: "SGD",
+  CH: "CHF",
+  SE: "SEK",
+  NO: "NOK",
+  DK: "DKK",
+  NZ: "NZD",
+  IN: "INR",
+  BR: "BRL",
+  MX: "MXN",
+  // ユーロ圏
+  DE: "EUR",
+  FR: "EUR",
+  IT: "EUR",
+  ES: "EUR",
+  NL: "EUR",
+  BE: "EUR",
+  AT: "EUR",
+  IE: "EUR",
+  PT: "EUR",
+  FI: "EUR",
+  GR: "EUR",
+};
+
+const FALLBACK_CURRENCY = "USD";
+
+export function detectCurrencyFromLocale(locale: string): string {
+  try {
+    const region = new Intl.Locale(locale).maximize().region;
+    if (!region) {
+      return FALLBACK_CURRENCY;
+    }
+    return REGION_TO_CURRENCY[region] ?? FALLBACK_CURRENCY;
+  } catch {
+    return FALLBACK_CURRENCY;
+  }
+}
+
+export function getCurrencyDecimalDigits(currency: string): number {
+  return new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency,
+  }).resolvedOptions().maximumFractionDigits;
+}
+
+export function formatCurrency(amount: number, currency: string, locale?: string): string {
+  return new Intl.NumberFormat(locale, {
+    style: "currency",
+    currency,
+  }).format(amount);
+}

--- a/frontend/src/lib/currency.ts
+++ b/frontend/src/lib/currency.ts
@@ -53,10 +53,11 @@ export function detectCurrencyFromLocale(locale: string): string {
 }
 
 export function getCurrencyDecimalDigits(currency: string): number {
-  return new Intl.NumberFormat(undefined, {
+  const { maximumFractionDigits } = new Intl.NumberFormat(undefined, {
     style: "currency",
     currency,
-  }).resolvedOptions().maximumFractionDigits;
+  }).resolvedOptions();
+  return maximumFractionDigits ?? 2;
 }
 
 export function formatCurrency(amount: number, currency: string, locale?: string): string {


### PR DESCRIPTION
## 概要

通貨コードを localStorage で永続化し、`Intl.NumberFormat` で金額を整形するカスタムフック `useCurrency` を追加する。通貨設定はフロントエンドで管理する方針（`docs/03-design/backend/domain-model.md`）に従い、Phase 2 の共通 UI 基盤として実装した。

## 変更内容

- `src/lib/currency.ts` — 純粋ユーティリティ
  - `detectCurrencyFromLocale(locale)` — `Intl.Locale.maximize()` でリージョンを抽出し通貨コードを推定（未知ロケールは USD にフォールバック）
  - `getCurrencyDecimalDigits(currency)` — ISO 4217 準拠の小数桁数を返す
  - `formatCurrency(amount, currency, locale?)` — 通貨付き金額整形
- `src/hooks/useCurrency.ts` — フック本体
  - `useSyncExternalStore` + localStorage キー `expense-tracker:currency` で永続化
  - モジュールレベル listeners + `storage` イベントで同一タブ・複数タブ間を同期
  - API: `{ currency, setCurrency, formatAmount, decimalDigits }`
- 各ファイルに対応するユニットテストを追加（計 17 + 8 = 25 件）

## 関連 Issue

Closes #248

## テスト

- `npm run check`（Prettier + ESLint + tsc + Vitest 166 件 + Playwright + build）すべて通過
- TDD サイクル（テスト先行 → 実装 → ビルド修正）でコミットを分割

---
🤖 Generated with [Claude Code](https://claude.ai/code)