### PR TITLE
refactor(frontend): UI プリミティブを shadcn/ui に統一

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -29,6 +29,8 @@ export default tseslint.config(
     files: ["src/components/ui/**/*.{ts,tsx}"],
     rules: {
       "react-refresh/only-export-components": "off",
+      // shadcn CLI が生成するコードをそのまま保持するため、UI プリミティブのみ型アサーション禁止を緩める
+      "@typescript-eslint/consistent-type-assertions": "off",
     },
   },
   eslintConfigPrettier,

--- a/frontend/src/components/BottomNav.tsx
+++ b/frontend/src/components/BottomNav.tsx
@@ -9,7 +9,7 @@ const tabs = [
 
 export function BottomNav() {
   return (
-    <nav className="fixed inset-x-0 bottom-0 border-t border-gray-200 bg-white">
+    <nav className="border-border bg-background fixed inset-x-0 bottom-0 border-t">
       <ul className="flex justify-around">
         {tabs.map(({ to, label, icon: Icon }) => (
           <li key={to}>
@@ -17,7 +17,7 @@ export function BottomNav() {
               to={to}
               className={({ isActive }) =>
                 `flex flex-col items-center px-3 py-2 text-xs ${
-                  isActive ? "text-blue-600" : "text-gray-500"
+                  isActive ? "text-primary" : "text-muted-foreground"
                 }`
               }
             >

--- a/frontend/src/components/PeriodSelector.test.tsx
+++ b/frontend/src/components/PeriodSelector.test.tsx
@@ -76,7 +76,7 @@ describe("PeriodSelector", () => {
     const onChange = vi.fn<(period: Period) => void>();
     render(<PeriodSelector onChange={onChange} />);
 
-    await user.click(screen.getByRole("button", { name: /^year$/i }));
+    await user.click(screen.getByRole("radio", { name: /^year$/i }));
 
     expect(screen.getByText("2026")).toBeInTheDocument();
     expect(onChange).toHaveBeenLastCalledWith({ from: "2026-01-01", to: "2026-12-31" });
@@ -87,7 +87,7 @@ describe("PeriodSelector", () => {
     const onChange = vi.fn<(period: Period) => void>();
     render(<PeriodSelector onChange={onChange} />);
 
-    await user.click(screen.getByRole("button", { name: /^year$/i }));
+    await user.click(screen.getByRole("radio", { name: /^year$/i }));
     await user.click(screen.getByRole("button", { name: /previous period/i }));
 
     expect(screen.getByText("2025")).toBeInTheDocument();
@@ -99,7 +99,7 @@ describe("PeriodSelector", () => {
     const onChange = vi.fn<(period: Period) => void>();
     render(<PeriodSelector onChange={onChange} />);
 
-    await user.click(screen.getByRole("button", { name: /^year$/i }));
+    await user.click(screen.getByRole("radio", { name: /^year$/i }));
     await user.click(screen.getByRole("button", { name: /next period/i }));
 
     expect(screen.getByText("2027")).toBeInTheDocument();
@@ -111,7 +111,7 @@ describe("PeriodSelector", () => {
     const onChange = vi.fn<(period: Period) => void>();
     render(<PeriodSelector onChange={onChange} />);
 
-    await user.click(screen.getByRole("button", { name: /^all$/i }));
+    await user.click(screen.getByRole("radio", { name: /^all$/i }));
 
     expect(screen.getByText("All Transactions")).toBeInTheDocument();
     expect(onChange).toHaveBeenLastCalledWith(null);
@@ -121,7 +121,7 @@ describe("PeriodSelector", () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
     render(<PeriodSelector onChange={vi.fn()} />);
 
-    await user.click(screen.getByRole("button", { name: /^all$/i }));
+    await user.click(screen.getByRole("radio", { name: /^all$/i }));
 
     expect(screen.queryByRole("button", { name: /previous period/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /next period/i })).not.toBeInTheDocument();
@@ -132,8 +132,8 @@ describe("PeriodSelector", () => {
     const onChange = vi.fn<(period: Period) => void>();
     render(<PeriodSelector onChange={onChange} />);
 
-    await user.click(screen.getByRole("button", { name: /^all$/i }));
-    await user.click(screen.getByRole("button", { name: /^month$/i }));
+    await user.click(screen.getByRole("radio", { name: /^all$/i }));
+    await user.click(screen.getByRole("radio", { name: /^month$/i }));
 
     expect(screen.getByText("February 2026")).toBeInTheDocument();
     expect(onChange).toHaveBeenLastCalledWith({ from: "2026-02-01", to: "2026-02-28" });

--- a/frontend/src/components/PeriodSelector.tsx
+++ b/frontend/src/components/PeriodSelector.tsx
@@ -1,9 +1,16 @@
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
+import { Button } from "@/components/ui/button";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+
 import { type IsoDate, toIsoDate } from "../lib/isoDate";
 
 type Unit = "month" | "year" | "all";
+
+function isUnit(value: string): value is Unit {
+  return value === "month" || value === "year" || value === "all";
+}
 
 export type Period = { from: IsoDate; to: IsoDate } | null;
 
@@ -60,8 +67,8 @@ export function PeriodSelector({ onChange }: PeriodSelectorProps) {
     onChangeRef.current(computePeriod(unit, anchor));
   }, [unit, anchor]);
 
-  const handleUnitChange = (nextUnit: Unit) => {
-    if (nextUnit === unit) return;
+  const handleUnitChange = (nextUnit: string) => {
+    if (!isUnit(nextUnit) || nextUnit === unit) return;
     setUnit(nextUnit);
     // 単位切替時は現在日時にリセット（「All → Month」で当月が戻るため）
     setAnchor(new Date());
@@ -73,50 +80,51 @@ export function PeriodSelector({ onChange }: PeriodSelectorProps) {
     <div className="flex flex-col gap-2">
       <div className="flex items-center justify-center gap-2">
         {showNav && (
-          <button
+          <Button
             type="button"
+            variant="ghost"
+            size="icon"
             aria-label="Previous period"
             onClick={() => {
               setAnchor((prev) => shiftAnchor(unit, prev, -1));
             }}
-            className="inline-flex h-8 w-8 items-center justify-center rounded text-gray-600 hover:bg-gray-100"
           >
-            <ChevronLeft className="h-5 w-5" />
-          </button>
+            <ChevronLeft />
+          </Button>
         )}
         <span className="min-w-40 text-center text-base font-medium">
           {formatLabel(unit, anchor)}
         </span>
         {showNav && (
-          <button
+          <Button
             type="button"
+            variant="ghost"
+            size="icon"
             aria-label="Next period"
             onClick={() => {
               setAnchor((prev) => shiftAnchor(unit, prev, 1));
             }}
-            className="inline-flex h-8 w-8 items-center justify-center rounded text-gray-600 hover:bg-gray-100"
           >
-            <ChevronRight className="h-5 w-5" />
-          </button>
+            <ChevronRight />
+          </Button>
         )}
       </div>
-      <div role="group" className="flex justify-center gap-1 text-sm">
-        {(["month", "year", "all"] as const).map((u) => (
-          <button
-            key={u}
-            type="button"
-            aria-pressed={unit === u}
-            onClick={() => {
-              handleUnitChange(u);
-            }}
-            className={`rounded px-3 py-1 ${
-              unit === u ? "bg-blue-600 text-white" : "bg-gray-100 text-gray-700"
-            }`}
-          >
-            {u === "month" ? "Month" : u === "year" ? "Year" : "All"}
-          </button>
-        ))}
-      </div>
+      <ToggleGroup
+        type="single"
+        value={unit}
+        onValueChange={handleUnitChange}
+        className="self-center"
+      >
+        <ToggleGroupItem value="month" aria-label="Month">
+          Month
+        </ToggleGroupItem>
+        <ToggleGroupItem value="year" aria-label="Year">
+          Year
+        </ToggleGroupItem>
+        <ToggleGroupItem value="all" aria-label="All">
+          All
+        </ToggleGroupItem>
+      </ToggleGroup>
     </div>
   );
 }

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -1,0 +1,45 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { Slot } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        secondary: "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+        destructive:
+          "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
+        outline: "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
+        ghost: "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function Badge({
+  className,
+  variant = "default",
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> & VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "span";
+
+  return (
+    <Comp
+      data-slot="badge"
+      data-variant={variant}
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -1,0 +1,92 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Card({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<"div"> & { size?: "default" | "sm" }) {
+  return (
+    <div
+      data-slot="card"
+      data-size={size}
+      className={cn(
+        "group/card bg-card text-card-foreground ring-foreground/10 flex flex-col gap-4 overflow-hidden rounded-xl py-4 text-sm ring-1 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-xl px-4 group-data-[size=sm]/card:px-3 has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn(
+        "font-heading text-base leading-snug font-medium group-data-[size=sm]/card:text-sm",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn("col-start-2 row-span-2 row-start-1 self-start justify-self-end", className)}
+      {...props}
+    />
+  );
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-4 group-data-[size=sm]/card:px-3", className)}
+      {...props}
+    />
+  );
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn(
+        "bg-muted/50 flex items-center rounded-b-xl border-t p-4 group-data-[size=sm]/card:p-3",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Card, CardHeader, CardFooter, CardTitle, CardAction, CardDescription, CardContent };

--- a/frontend/src/components/ui/toggle-group.tsx
+++ b/frontend/src/components/ui/toggle-group.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import * as React from "react";
+import { type VariantProps } from "class-variance-authority";
+import { ToggleGroup as ToggleGroupPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+import { toggleVariants } from "@/components/ui/toggle";
+
+const ToggleGroupContext = React.createContext<
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number;
+    orientation?: "horizontal" | "vertical";
+  }
+>({
+  size: "default",
+  variant: "default",
+  spacing: 0,
+  orientation: "horizontal",
+});
+
+function ToggleGroup({
+  className,
+  variant,
+  size,
+  spacing = 0,
+  orientation = "horizontal",
+  children,
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Root> &
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number;
+    orientation?: "horizontal" | "vertical";
+  }) {
+  return (
+    <ToggleGroupPrimitive.Root
+      data-slot="toggle-group"
+      data-variant={variant}
+      data-size={size}
+      data-spacing={spacing}
+      data-orientation={orientation}
+      style={{ "--gap": spacing } as React.CSSProperties}
+      className={cn(
+        "group/toggle-group flex w-fit flex-row items-center gap-[--spacing(var(--gap))] rounded-lg data-vertical:flex-col data-vertical:items-stretch data-[size=sm]:rounded-[min(var(--radius-md),10px)]",
+        className,
+      )}
+      {...props}
+    >
+      <ToggleGroupContext.Provider value={{ variant, size, spacing, orientation }}>
+        {children}
+      </ToggleGroupContext.Provider>
+    </ToggleGroupPrimitive.Root>
+  );
+}
+
+function ToggleGroupItem({
+  className,
+  children,
+  variant = "default",
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Item> & VariantProps<typeof toggleVariants>) {
+  const context = React.useContext(ToggleGroupContext);
+
+  return (
+    <ToggleGroupPrimitive.Item
+      data-slot="toggle-group-item"
+      data-variant={context.variant || variant}
+      data-size={context.size || size}
+      data-spacing={context.spacing}
+      className={cn(
+        "shrink-0 group-data-[spacing=0]/toggle-group:rounded-none group-data-[spacing=0]/toggle-group:px-2 focus:z-10 focus-visible:z-10 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-end]:pr-1.5 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-start]:pl-1.5 group-data-horizontal/toggle-group:data-[spacing=0]:first:rounded-l-lg group-data-vertical/toggle-group:data-[spacing=0]:first:rounded-t-lg group-data-horizontal/toggle-group:data-[spacing=0]:last:rounded-r-lg group-data-vertical/toggle-group:data-[spacing=0]:last:rounded-b-lg group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:border-l-0 group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:border-t-0 group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-l group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-t",
+        toggleVariants({
+          variant: context.variant || variant,
+          size: context.size || size,
+        }),
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </ToggleGroupPrimitive.Item>
+  );
+}
+
+export { ToggleGroup, ToggleGroupItem };

--- a/frontend/src/components/ui/toggle.tsx
+++ b/frontend/src/components/ui/toggle.tsx
@@ -1,0 +1,44 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { Toggle as TogglePrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+const toggleVariants = cva(
+  "group/toggle inline-flex items-center justify-center gap-1 rounded-lg text-sm font-medium whitespace-nowrap transition-all outline-none hover:bg-muted hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-pressed:bg-muted data-[state=on]:bg-muted dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline: "border border-input bg-transparent hover:bg-muted",
+      },
+      size: {
+        default:
+          "h-8 min-w-8 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        sm: "h-7 min-w-7 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        lg: "h-9 min-w-9 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+function Toggle({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof TogglePrimitive.Root> & VariantProps<typeof toggleVariants>) {
+  return (
+    <TogglePrimitive.Root
+      data-slot="toggle"
+      className={cn(toggleVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+}
+
+export { Toggle, toggleVariants };

--- a/frontend/src/features/auth/components/LoginPage.tsx
+++ b/frontend/src/features/auth/components/LoginPage.tsx
@@ -2,6 +2,8 @@ import { GoogleLogin } from "@react-oauth/google";
 import { useState } from "react";
 import { Navigate } from "react-router";
 
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+
 import { getToken } from "../../../lib/auth";
 import { useGoogleLogin } from "../api/useGoogleLogin";
 
@@ -14,11 +16,12 @@ export default function LoginPage() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
-      <div className="w-full max-w-sm text-center">
-        <h1 className="mb-8 text-3xl font-bold text-gray-900">Expense Tracker</h1>
-
-        <div className="flex justify-center">
+    <div className="bg-muted flex min-h-screen items-center justify-center px-4">
+      <Card className="w-full max-w-sm">
+        <CardHeader className="text-center">
+          <h1 className="font-heading text-2xl leading-snug font-medium">Expense Tracker</h1>
+        </CardHeader>
+        <CardContent className="flex flex-col items-center gap-4">
           <GoogleLogin
             onSuccess={(response) => {
               if (response.credential) {
@@ -34,20 +37,20 @@ export default function LoginPage() {
             shape="rectangular"
             width="300"
           />
-        </div>
 
-        {errorMessage && (
-          <p role="alert" className="mt-4 text-sm text-red-600">
-            {errorMessage}
-          </p>
-        )}
+          {errorMessage && (
+            <p role="alert" className="text-destructive text-sm">
+              {errorMessage}
+            </p>
+          )}
 
-        {googleLogin.isError && (
-          <p role="alert" className="mt-4 text-sm text-red-600">
-            ログインに失敗しました。もう一度お試しください。
-          </p>
-        )}
-      </div>
+          {googleLogin.isError && (
+            <p role="alert" className="text-destructive text-sm">
+              ログインに失敗しました。もう一度お試しください。
+            </p>
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/frontend/src/features/transactions/components/TransactionItem.tsx
+++ b/frontend/src/features/transactions/components/TransactionItem.tsx
@@ -1,5 +1,7 @@
-import { getCategoryEmoji } from "../../../lib/category-emoji";
+import { Badge } from "@/components/ui/badge";
+
 import { useCurrency } from "../../../hooks/useCurrency";
+import { getCategoryEmoji } from "../../../lib/category-emoji";
 import type { Transaction } from "../types";
 
 interface TransactionItemProps {
@@ -20,18 +22,12 @@ export function TransactionItem({ transaction }: TransactionItemProps) {
       <span className="text-xl" aria-hidden="true">
         {emoji}
       </span>
-      <span className="flex-1 truncate text-sm text-gray-900">{displayTitle}</span>
-      <span className="text-sm font-medium text-gray-900">{formatAmount(amountNumber)}</span>
+      <span className="text-foreground flex-1 truncate text-sm">{displayTitle}</span>
+      <span className="text-foreground text-sm font-medium">{formatAmount(amountNumber)}</span>
       {transaction.needWantType !== "UNSET" && (
-        <span
-          className={`rounded px-2 py-0.5 text-xs font-medium ${
-            transaction.needWantType === "NEED"
-              ? "bg-blue-100 text-blue-700"
-              : "bg-amber-100 text-amber-700"
-          }`}
-        >
+        <Badge variant={transaction.needWantType === "NEED" ? "secondary" : "outline"}>
           {transaction.needWantType}
-        </span>
+        </Badge>
       )}
     </div>
   );

--- a/frontend/src/features/transactions/components/TransactionList.tsx
+++ b/frontend/src/features/transactions/components/TransactionList.tsx
@@ -42,13 +42,15 @@ export function TransactionList({ transactions }: TransactionListProps) {
   const groups = groupByDate(transactions);
 
   return (
-    <div className="divide-y divide-gray-100">
+    <div className="divide-border divide-y">
       {groups.map((group) => {
         const heading = formatDateHeader(group.date);
         return (
           <section key={group.date} role="group" aria-label={heading}>
-            <h2 className="bg-gray-50 px-4 py-2 text-xs font-medium text-gray-500">{heading}</h2>
-            <ul className="divide-y divide-gray-100">
+            <h2 className="bg-muted text-muted-foreground px-4 py-2 text-xs font-medium">
+              {heading}
+            </h2>
+            <ul className="divide-border divide-y">
               {group.items.map((item) => (
                 <li key={item.id}>
                   <TransactionItem transaction={item} />

--- a/frontend/src/features/transactions/components/TransactionsPage.tsx
+++ b/frontend/src/features/transactions/components/TransactionsPage.tsx
@@ -1,6 +1,8 @@
 import { Plus } from "lucide-react";
 import { useState } from "react";
 
+import { Button } from "@/components/ui/button";
+
 import { PeriodSelector, type Period } from "../../../components/PeriodSelector";
 import { Spinner } from "../../../components/ui/spinner";
 import { useTransactions } from "../api/useTransactions";
@@ -19,7 +21,7 @@ export default function TransactionsPage() {
 
   return (
     <div className="relative min-h-screen">
-      <div className="sticky top-0 z-10 border-b border-gray-200 bg-white px-4 py-3">
+      <div className="border-border bg-background sticky top-0 z-10 border-b px-4 py-3">
         <PeriodSelector onChange={setPeriod} />
       </div>
       {data === undefined ? (
@@ -29,13 +31,14 @@ export default function TransactionsPage() {
       ) : (
         <TransactionList transactions={data.items} />
       )}
-      <button
+      <Button
         type="button"
+        size="icon"
         aria-label="Add transaction"
-        className="fixed right-6 bottom-20 inline-flex h-14 w-14 items-center justify-center rounded-full bg-blue-600 text-white shadow-lg hover:bg-blue-700"
+        className="fixed right-6 bottom-20 size-14 rounded-full shadow-lg [&_svg:not([class*='size-'])]:size-6"
       >
-        <Plus className="h-6 w-6" />
-      </button>
+        <Plus />
+      </Button>
     </div>
   );
 }


### PR DESCRIPTION
## 概要
UI プリミティブとして導入済みだった shadcn/ui を、生 `<button>` / `<span>` + Tailwind マジックナンバー（`bg-blue-600` 等）で実装されていた箇所に行き渡らせ、デザイントークン経由の表現に統一する。

## 変更内容
- shadcn の `Badge` / `Card` / `Toggle` / `ToggleGroup` を CLI で追加（`src/components/ui/`）
  - 生成コードに含まれる CSS 変数の型アサーションを許容するため、`src/components/ui/**` に対して `@typescript-eslint/consistent-type-assertions` を緩めた
- `TransactionItem`: NEED/WANT のピルを `Badge`（NEED=secondary / WANT=outline）に置き換え
- `PeriodSelector`: 単位切替を `ToggleGroup` + `ToggleGroupItem`、前/次月の矢印を `Button variant=ghost size=icon` に置き換え（テストの `role="button"` を `role="radio"` に追従）
- `TransactionsPage`: FAB を `Button size=icon` + `rounded-full size-14` に置き換え。ヘッダ枠を `border-border` / `bg-background` に
- `TransactionList` / `BottomNav`: `bg-gray-* / text-blue-* / border-gray-*` をデザイントークン（`bg-muted` / `text-primary` / `border-border` 等）に統一
- `LoginPage`: 中央フォームを `Card` + `CardHeader` + `CardContent` で構造化。`CardTitle` は `<div>` で `heading` role を持たないため、見出しは `<h1>` を `CardHeader` 直下に置いて支援技術からの可達性を維持

## 関連 Issue
なし（リファクタリング）

## スクリーンショット
- `frontend/screenshots/login-redirect.png` — Card 化されたログイン画面
- `frontend/screenshots/transactions-empty.png` — ToggleGroup / ghost 矢印 / 黒丸 FAB / トークン化された BottomNav
- `frontend/screenshots/shadcn-login.png` — モバイル幅（390px）でのログイン画面

## テスト
- `npm run check`（prettier + eslint + tsc + vitest 187 件 + playwright 2 件 + vite build）すべてパス
- Playwright MCP でログイン画面・取引一覧空状態を視覚確認

---
🤖 Generated with [Claude Code](https://claude.ai/code)