### PR TITLE
fix(frontend): E2E ログイン画面で Google ボタンを描画する仕組みを整える

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -50,6 +50,20 @@ src/
 - **認証フロー**: Google OAuth2 でクライアントサイド ID トークン取得 → `POST /api/v1/auth/google` → JWT 返却。詳細は @docs/03-design/common/auth-design.md
 - **UI プリミティブ**: shadcn/ui（Radix UI + Tailwind CSS ベース）を採用。コピー & ペースト型で、ソースコードをプロジェクト内に取り込む
 
+## 環境変数
+
+Vite の mode ベースで環境ごとに `.env.*` を分割する。Vite が `--mode <name>` 起動時に `.env`・`.env.<mode>`・`.env.local`・`.env.<mode>.local` の順で読み込み、後勝ちでマージする。
+
+| ファイル | git | 用途 |
+|---|---|---|
+| `.env.example` | コミット | 公開キーのテンプレート。新規セットアップ時に `.env.development.local` 等にコピーして実値を埋める |
+| `.env.e2e` | コミット | E2E (`npm run build:e2e` = `vite build --mode e2e`) 専用の値 |
+| `.env*.local` | 無視 | 個別開発者の実値・本番シークレット |
+
+- `VITE_` プレフィックスのキーのみ `import.meta.env` 経由でクライアントから参照できる。シークレットを誤って公開しないよう、機密値は `VITE_` を付けず BE 側で扱う
+- 本番ビルドは CI のシークレットから `VITE_*` を inject し、`.env.production` をリポジトリに置かない
+- E2E では実 GSI が origin 検証で hidden になるため、`MODE === "e2e"` のときに `GoogleSignInButton` をスタブに切り替える方式で逃がしている（`features/auth/components/GoogleSignInButton.tsx`）。新たに外部 SDK 依存のコンポーネントを足すときも同様の分岐を検討する
+
 ## UI コンポーネントライブラリ: shadcn/ui
 
 - プリミティブ（`Button`, `Dialog`, `Spinner` など）は `npx shadcn@latest add <component>` で `src/components/ui/` に追加する

--- a/README.md
+++ b/README.md
@@ -71,7 +71,26 @@ src/
 
 ### 環境変数
 
-- 'CONTEXT7_API_KEY': Context7 MCPサーバー接続利用時に必要。
+#### Dev Container / ホスト共通
+
+- `CONTEXT7_API_KEY`: Context7 MCPサーバー接続利用時に必要。
+
+#### Frontend (`frontend/.env.*`)
+
+Vite の mode ベースで環境別に分割する。詳細は `.claude/rules/frontend.md` の「環境変数」を参照。
+
+| ファイル | git | 用途 |
+| --- | --- | --- |
+| `.env.example` | コミット | 公開キーのテンプレート |
+| `.env.e2e` | コミット | E2E (`npm run build:e2e`) 専用 |
+| `.env.development.local` 等 | 無視 | 開発者個別の実値（コピーして編集） |
+
+主なキー:
+
+- `VITE_GOOGLE_CLIENT_ID`: Google OAuth クライアント ID。空文字だと GSI 初期化失敗でログインボタンが描画されない
+- `VITE_ENABLE_MSW`: MSW (Mock Service Worker) を有効化。E2E ビルドで `true`、開発時は既定で無効
+
+ローカル開発を始める前に `cp frontend/.env.example frontend/.env.development.local` で雛形を複製し、自分の Client ID を記入する。
 
 ### Dev Container（推奨）
 

--- a/frontend/.env.e2e
+++ b/frontend/.env.e2e
@@ -1,0 +1,9 @@
+# E2E (Playwright) ビルド専用の環境変数。
+# `vite build --mode e2e` で読み込まれる。実トークンは含めない。
+
+# MSW でバックエンドをモックする
+VITE_ENABLE_MSW=true
+
+# GSI の `renderButton` は client_id が非空であれば iframe を可視状態で描画する。
+# E2E では実 OAuth フローを踏まないため、ダミー値で十分。
+VITE_GOOGLE_CLIENT_ID=000000000000-e2edummye2edummye2edummye2edummy.apps.googleusercontent.com

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,11 @@
+# フロントエンド環境変数のテンプレート。
+# 個別の実値は `.env.development.local` / `.env.local` 等（gitignore 済み）に書く。
+
+# Google OAuth 2.0 クライアント ID
+# https://console.cloud.google.com/apis/credentials で発行する。
+# 空文字だと GSI の初期化が失敗してログインボタンが描画されない点に注意。
+VITE_GOOGLE_CLIENT_ID=
+
+# MSW (Mock Service Worker) を有効化するか。
+# 既定は無効。E2E ビルド (`build:e2e`) でのみ true にする。
+VITE_ENABLE_MSW=false

--- a/frontend/e2e/app.spec.ts
+++ b/frontend/e2e/app.spec.ts
@@ -7,6 +7,11 @@ test("未認証でトップページにアクセスするとログインペー�
   await expect(page).toHaveURL(/\/login/);
   await expect(page.getByRole("heading", { name: "Expense Tracker" })).toBeVisible();
 
+  // GSI が描画する Google サインインボタンの iframe が表示されていること。
+  // Client ID 未設定 / GSI 初期化失敗時はこの iframe が挿入されないため、
+  // 「ログイン手段が画面に存在する」ことのリグレッション検知になる。
+  await expect(page.locator("iframe[src*='accounts.google.com/gsi/button']")).toBeVisible();
+
   await page.screenshot({ path: "screenshots/login-redirect.png", fullPage: true });
 });
 

--- a/frontend/e2e/app.spec.ts
+++ b/frontend/e2e/app.spec.ts
@@ -7,10 +7,9 @@ test("未認証でトップページにアクセスするとログインペー�
   await expect(page).toHaveURL(/\/login/);
   await expect(page.getByRole("heading", { name: "Expense Tracker" })).toBeVisible();
 
-  // GSI が描画する Google サインインボタンの iframe が表示されていること。
-  // Client ID 未設定 / GSI 初期化失敗時はこの iframe が挿入されないため、
-  // 「ログイン手段が画面に存在する」ことのリグレッション検知になる。
-  await expect(page.locator("iframe[src*='accounts.google.com/gsi/button']")).toBeVisible();
+  // E2E ビルドでは GoogleSignInButton が GSI iframe ではなくスタブボタンを描画する。
+  // ログイン手段が画面に存在することのリグレッション検知。
+  await expect(page.getByRole("button", { name: /sign in with google/i })).toBeVisible();
 
   await page.screenshot({ path: "screenshots/login-redirect.png", fullPage: true });
 });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,7 @@
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "build:msw": "VITE_ENABLE_MSW=true vite build",
+    "build:e2e": "vite build --mode e2e",
     "openapi:types": "openapi-typescript ../backend/openapi.yaml -o src/types/api-generated.ts",
     "check": "prettier --check . && eslint . && tsc -b && vitest run && playwright test && vite build"
   },

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: "npm run build:msw && npm run preview",
+    command: "npm run build:e2e && npm run preview",
     url: "http://localhost:4173",
     reuseExistingServer: !process.env.CI,
   },

--- a/frontend/src/features/auth/components/GoogleSignInButton.tsx
+++ b/frontend/src/features/auth/components/GoogleSignInButton.tsx
@@ -1,0 +1,36 @@
+import { GoogleLogin, type CredentialResponse } from "@react-oauth/google";
+
+interface GoogleSignInButtonProps {
+  onSuccess: (response: CredentialResponse) => void;
+  onError: () => void;
+}
+
+// E2E (`vite build --mode e2e`) では実 GSI iframe が Google サーバーの origin 検証で
+// hidden にされ、ボタンを描画できない。E2E で OAuth フロー自体は MSW が
+// `/api/v1/auth/google` を返すため、ここでは credential を素通しするスタブに差し替える。
+export function GoogleSignInButton({ onSuccess, onError }: GoogleSignInButtonProps) {
+  if (import.meta.env.MODE === "e2e") {
+    return (
+      <button
+        type="button"
+        onClick={() => {
+          onSuccess({ credential: "e2e-fake-credential", select_by: "btn" });
+        }}
+        className="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-10 items-center justify-center rounded-md px-4 text-sm font-medium"
+      >
+        Sign in with Google
+      </button>
+    );
+  }
+
+  return (
+    <GoogleLogin
+      onSuccess={onSuccess}
+      onError={onError}
+      size="large"
+      text="signin_with"
+      shape="rectangular"
+      width="300"
+    />
+  );
+}

--- a/frontend/src/features/auth/components/LoginPage.tsx
+++ b/frontend/src/features/auth/components/LoginPage.tsx
@@ -1,4 +1,3 @@
-import { GoogleLogin } from "@react-oauth/google";
 import { useState } from "react";
 import { Navigate } from "react-router";
 
@@ -6,6 +5,7 @@ import { Card, CardContent, CardHeader } from "@/components/ui/card";
 
 import { getToken } from "../../../lib/auth";
 import { useGoogleLogin } from "../api/useGoogleLogin";
+import { GoogleSignInButton } from "./GoogleSignInButton";
 
 export default function LoginPage() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -22,7 +22,7 @@ export default function LoginPage() {
           <h1 className="font-heading text-2xl leading-snug font-medium">Expense Tracker</h1>
         </CardHeader>
         <CardContent className="flex flex-col items-center gap-4">
-          <GoogleLogin
+          <GoogleSignInButton
             onSuccess={(response) => {
               if (response.credential) {
                 setErrorMessage(null);
@@ -32,10 +32,6 @@ export default function LoginPage() {
             onError={() => {
               setErrorMessage("Google認証に失敗しました。もう一度お試しください。");
             }}
-            size="large"
-            text="signin_with"
-            shape="rectangular"
-            width="300"
           />
 
           {errorMessage && (


### PR DESCRIPTION
## 概要

E2E のスクリーンショット (`screenshots/login-redirect.png`) に Google 認証ボタンが表示されていなかった問題を修正する。原因は `VITE_GOOGLE_CLIENT_ID` が未設定で GSI 初期化が失敗していたこと、加えて E2E のアサーションがログインボタンの存在を検証していなかったこと。併せてフロントエンドの環境変数を mode ベースに整理する。

## 変更内容

- **TDD で E2E アサーションを追加**: `app.spec.ts` でログイン画面の Google サインインボタンの可視性を検証する。リグレッション検知になる
- **mode ベースの `.env` 構成に整理**: `.env.example`（テンプレート）と `.env.e2e`（E2E ビルド専用）を新設。`build:msw` を `vite build --mode e2e` に置換し、E2E 固有の値は `.env.e2e` に集約
- **GSI 回避スタブを導入**: GSI は client_id を Google サーバー側で origin 検証するため、ダミー値では iframe が hidden で描画されない。`features/auth/components/GoogleSignInButton.tsx` を新設し、`MODE === "e2e"` のときは credential を素通しするスタブボタンに切り替える（MSW が `/api/v1/auth/google` をモックするのでフローは完結する）
- **ドキュメント更新**: `README.md` と `.claude/rules/frontend.md` に環境変数の管理方針を明文化

## 関連 Issue

Closes #294

## スクリーンショット

frontend/screensho
<img width="1280" height="720" alt="login-redirect" src="https://github.com/user-attachments/assets/195f2348-b6f0-4d1c-9fcb-081a83fb6320" />
ts/login-redirect.png


## テスト

- [x] `npm run check`（Prettier + ESLint + tsc + Vitest 187 件 + Playwright 2 件 + ビルド）グリーン
- [x] `screenshots/login-redirect.png` に "Sign in with Google" ボタンが描画されることを目視確認
- [x] Red 確認 → Green 確認のコミット履歴で TDD サイクルを残している

---
🤖 Generated with [Claude Code](https://claude.ai/code)