### PR TITLE
refactor(frontend): /simplify レビュー結果の改善項目を反映

### DIFF
--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -10,9 +10,9 @@ interface EmptyStateProps {
 export function EmptyState({ title, description, icon, action }: EmptyStateProps) {
   return (
     <div className="flex flex-col items-center justify-center gap-3 px-6 py-12 text-center">
-      {icon && <div className="text-gray-400">{icon}</div>}
-      <p className="text-base font-medium text-gray-900">{title}</p>
-      {description && <p className="text-sm text-gray-500">{description}</p>}
+      {icon && <div className="text-muted-foreground">{icon}</div>}
+      <p className="text-foreground text-base font-medium">{title}</p>
+      {description && <p className="text-muted-foreground text-sm">{description}</p>}
       {action && <div className="mt-2">{action}</div>}
     </div>
   );

--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -22,13 +22,22 @@ export function ToastProvider({ children }: ToastProviderProps) {
     setToasts((prev) => prev.filter((t) => t.id !== id));
   }, []);
 
-  const showSuccess = useCallback((message: string) => {
-    setToasts((prev) => [...prev, { id: crypto.randomUUID(), variant: "success", message }]);
+  const push = useCallback((variant: ToastItem["variant"], message: string) => {
+    setToasts((prev) => [...prev, { id: crypto.randomUUID(), variant, message }]);
   }, []);
 
-  const showError = useCallback((message: string) => {
-    setToasts((prev) => [...prev, { id: crypto.randomUUID(), variant: "error", message }]);
-  }, []);
+  const showSuccess = useCallback(
+    (message: string) => {
+      push("success", message);
+    },
+    [push],
+  );
+  const showError = useCallback(
+    (message: string) => {
+      push("error", message);
+    },
+    [push],
+  );
 
   const value = useMemo<ToastContextValue>(
     () => ({ showSuccess, showError }),

--- a/frontend/src/features/categories/types.ts
+++ b/frontend/src/features/categories/types.ts
@@ -1,1 +1,0 @@
-export type { Category } from "../../types/api";

--- a/frontend/src/features/transactions/components/TransactionList.tsx
+++ b/frontend/src/features/transactions/components/TransactionList.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from "react";
+
 import { EmptyState } from "../../../components/EmptyState";
 import type { Transaction } from "../types";
 import { TransactionItem } from "./TransactionItem";
@@ -35,11 +37,11 @@ function groupByDate(transactions: Transaction[]): { date: string; items: Transa
 }
 
 export function TransactionList({ transactions }: TransactionListProps) {
+  const groups = useMemo(() => groupByDate(transactions), [transactions]);
+
   if (transactions.length === 0) {
     return <EmptyState title="No transactions yet. Tap + to add your first one!" />;
   }
-
-  const groups = groupByDate(transactions);
 
   return (
     <div className="divide-border divide-y">

--- a/frontend/src/hooks/useCurrency.ts
+++ b/frontend/src/hooks/useCurrency.ts
@@ -1,22 +1,31 @@
 import { useCallback, useMemo, useSyncExternalStore } from "react";
 
-import { detectCurrencyFromLocale, formatCurrency, getCurrencyDecimalDigits } from "@/lib/currency";
+import {
+  detectCurrencyFromLocale,
+  getCurrencyDecimalDigits,
+  getCurrencyFormatter,
+} from "@/lib/currency";
 
 const STORAGE_KEY = "expense-tracker:currency";
 
 const listeners = new Set<() => void>();
 
+function notify(): void {
+  listeners.forEach((listener) => {
+    listener();
+  });
+}
+
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", (event) => {
+    if (event.key === STORAGE_KEY) notify();
+  });
+}
+
 function subscribe(listener: () => void): () => void {
   listeners.add(listener);
-  const handleStorage = (event: StorageEvent) => {
-    if (event.key === STORAGE_KEY) {
-      listener();
-    }
-  };
-  window.addEventListener("storage", handleStorage);
   return () => {
     listeners.delete(listener);
-    window.removeEventListener("storage", handleStorage);
   };
 }
 
@@ -40,16 +49,11 @@ export function useCurrency(): UseCurrencyReturn {
 
   const setCurrency = useCallback((code: string) => {
     localStorage.setItem(STORAGE_KEY, code);
-    listeners.forEach((listener) => {
-      listener();
-    });
+    notify();
   }, []);
 
-  const formatAmount = useCallback(
-    (amount: number) => formatCurrency(amount, currency),
-    [currency],
-  );
-
+  const formatter = useMemo(() => getCurrencyFormatter(currency), [currency]);
+  const formatAmount = useCallback((amount: number) => formatter.format(amount), [formatter]);
   const decimalDigits = useMemo(() => getCurrencyDecimalDigits(currency), [currency]);
 
   return { currency, setCurrency, formatAmount, decimalDigits };

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -26,7 +26,6 @@ interface RequestOptions {
   skipAuth?: boolean;
 }
 
-// TODO: feature 層実装時に戻り値型をジェネリクス化するか、呼び出し側で Zod parse するか方針を決定する
 async function request(
   method: string,
   path: string,

--- a/frontend/src/lib/currency.ts
+++ b/frontend/src/lib/currency.ts
@@ -52,17 +52,22 @@ export function detectCurrencyFromLocale(locale: string): string {
   }
 }
 
+const formatterCache = new Map<string, Intl.NumberFormat>();
+
+export function getCurrencyFormatter(currency: string, locale?: string): Intl.NumberFormat {
+  const key = `${locale ?? ""}|${currency}`;
+  let formatter = formatterCache.get(key);
+  if (!formatter) {
+    formatter = new Intl.NumberFormat(locale, { style: "currency", currency });
+    formatterCache.set(key, formatter);
+  }
+  return formatter;
+}
+
 export function getCurrencyDecimalDigits(currency: string): number {
-  const { maximumFractionDigits } = new Intl.NumberFormat(undefined, {
-    style: "currency",
-    currency,
-  }).resolvedOptions();
-  return maximumFractionDigits ?? 2;
+  return getCurrencyFormatter(currency).resolvedOptions().maximumFractionDigits ?? 2;
 }
 
 export function formatCurrency(amount: number, currency: string, locale?: string): string {
-  return new Intl.NumberFormat(locale, {
-    style: "currency",
-    currency,
-  }).format(amount);
+  return getCurrencyFormatter(currency, locale).format(amount);
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -53,7 +53,7 @@ void enableMocking().then(() => {
         <QueryClientProvider client={queryClient}>
           <ToastProvider>
             <RouterProvider router={router} />
-            <ReactQueryDevtools initialIsOpen={false} />
+            {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
           </ToastProvider>
         </QueryClientProvider>
       </GoogleOAuthProvider>


### PR DESCRIPTION
## 概要

`/simplify` で frontend 全体のレビュー（Code Reuse / Code Quality / Efficiency）を実施し、明確に効果がある項目を取り込む。詳細とトラッキングは #298。

## 変更内容

- `useCurrency`: window storage リスナーを購読者ごとから 1 回限りに集約。`Intl.NumberFormat` を currency 単位でキャッシュ（`getCurrencyFormatter`）。`TransactionItem` を N 件描画しても formatter は currency 数だけ。
- `TransactionList`: `groupByDate(transactions)` を `useMemo` 化。
- `Toast`: `showSuccess`/`showError` を `push(variant, message)` ヘルパーに集約しドリフトを防止。
- `EmptyState`: `text-gray-*` を `text-muted-foreground` / `text-foreground` に置換（frontend.md のデザイントークン規約準拠）。
- `lib/api/client.ts`: 陳腐化した TODO を削除。
- `features/categories/types.ts`: 単純な re-export のみで未使用のため削除。
- `main.tsx`: `ReactQueryDevtools` を `import.meta.env.DEV` で gate し本番バンドルから除外。

## 関連 Issue

Refs #298

未対応項目はサブ Issue として #298 の sub_issues に登録済み:
- HIGH: #299 (types/api.ts と api-generated.ts の二重定義), #300 (PeriodSelector controlled 化)
- LOW: #301 (useTransactions staleTime), #302 (LoginPage エラー表示), #303 (GoogleSignInButton E2E スタブ), #304 (route lazy / vendor chunk)

## スクリーンショット

EmptyState のみ視覚的変更があるが、デザイントークンへの置換のためデフォルト光モードでは視覚差は軽微。ダーク対応時に効果が出る。

## テスト

- [x] `npm run check`（Prettier + ESLint + tsc + Vitest 187 / Playwright 2 + Vite build）すべてグリーン

---
🤖 Generated with [Claude Code](https://claude.ai/code)