### PR TITLE
feat(frontend): 支出削除機能を追加

### DIFF
--- a/frontend/src/features/transactions/api/useDeleteTransaction.test.tsx
+++ b/frontend/src/features/transactions/api/useDeleteTransaction.test.tsx
@@ -1,0 +1,105 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import type { ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+
+import { server } from "../../../test/mocks/server";
+import { useDeleteTransaction } from "./useDeleteTransaction";
+import { useTransactions } from "./useTransactions";
+
+interface WrapperContext {
+  queryClient: QueryClient;
+  Wrapper: (props: { children: ReactNode }) => ReactNode;
+}
+
+function createWrapper(): WrapperContext {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  }
+  return { queryClient, Wrapper };
+}
+
+describe("useDeleteTransaction", () => {
+  it("resolves when the API responds with 204", async () => {
+    server.use(
+      http.delete("/api/v1/transactions/:id", () => {
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useDeleteTransaction(), { wrapper: Wrapper });
+
+    result.current.mutate(42);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+  });
+
+  it("sends a DELETE request to the path containing the given id", async () => {
+    let capturedUrl = "";
+    let capturedMethod = "";
+    server.use(
+      http.delete("/api/v1/transactions/:id", ({ request }) => {
+        capturedUrl = request.url;
+        capturedMethod = request.method;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useDeleteTransaction(), { wrapper: Wrapper });
+
+    result.current.mutate(123);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(capturedMethod).toBe("DELETE");
+    expect(capturedUrl).toContain("/api/v1/transactions/123");
+  });
+
+  it("invalidates the transactions query after a successful delete", async () => {
+    let getCallCount = 0;
+    server.use(
+      http.get("/api/v1/transactions", () => {
+        getCallCount += 1;
+        return HttpResponse.json({ items: [] });
+      }),
+      http.delete("/api/v1/transactions/:id", () => {
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => ({
+        list: useTransactions({}),
+        delete: useDeleteTransaction(),
+      }),
+      { wrapper: Wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.list.isSuccess).toBe(true);
+    });
+    expect(getCallCount).toBe(1);
+
+    result.current.delete.mutate(1);
+
+    await waitFor(() => {
+      expect(result.current.delete.isSuccess).toBe(true);
+    });
+    await waitFor(() => {
+      expect(getCallCount).toBe(2);
+    });
+  });
+});

--- a/frontend/src/features/transactions/api/useDeleteTransaction.ts
+++ b/frontend/src/features/transactions/api/useDeleteTransaction.ts
@@ -1,0 +1,18 @@
+/** @see docs/03-design/backend/api-design.md */
+
+import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/react-query";
+
+import { apiClient } from "../../../lib/api/client";
+
+export function useDeleteTransaction(): UseMutationResult<void, Error, number> {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (id: number): Promise<void> => {
+      await apiClient.del(`/api/v1/transactions/${id.toString()}`);
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["transactions"] });
+    },
+  });
+}

--- a/frontend/src/features/transactions/components/DeleteConfirmDialog.test.tsx
+++ b/frontend/src/features/transactions/components/DeleteConfirmDialog.test.tsx
@@ -1,0 +1,127 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Transaction } from "../../../types/api";
+import { DeleteConfirmDialog } from "./DeleteConfirmDialog";
+
+const CURRENCY_KEY = "expense-tracker:currency";
+
+const TRANSACTION: Transaction = {
+  id: 99,
+  date: "2026-04-20",
+  amount: "1500",
+  categoryId: 1,
+  categoryName: "Food",
+  needWantType: "NEED",
+  title: "Lunch",
+  memo: "with team",
+  createdAt: "2026-04-20T10:00:00Z",
+  updatedAt: "2026-04-20T10:00:00Z",
+};
+
+describe("DeleteConfirmDialog", () => {
+  beforeEach(() => {
+    localStorage.setItem(CURRENCY_KEY, "USD");
+  });
+
+  afterEach(() => {
+    localStorage.removeItem(CURRENCY_KEY);
+  });
+
+  it("renders the target transaction's date, amount, and category", () => {
+    render(
+      <DeleteConfirmDialog
+        open
+        transaction={TRANSACTION}
+        isDeleting={false}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("2026-04-20")).toBeInTheDocument();
+    expect(screen.getByText(/\$1,500/)).toBeInTheDocument();
+    expect(screen.getByText("Food")).toBeInTheDocument();
+  });
+
+  it("renders Delete and Cancel buttons", () => {
+    render(
+      <DeleteConfirmDialog
+        open
+        transaction={TRANSACTION}
+        isDeleting={false}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /^delete$/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^cancel$/i })).toBeInTheDocument();
+  });
+
+  it("calls onConfirm when Delete button is clicked", async () => {
+    const onConfirm = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <DeleteConfirmDialog
+        open
+        transaction={TRANSACTION}
+        isDeleting={false}
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /^delete$/i }));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onCancel when Cancel button is clicked", async () => {
+    const onCancel = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <DeleteConfirmDialog
+        open
+        transaction={TRANSACTION}
+        isDeleting={false}
+        onConfirm={vi.fn()}
+        onCancel={onCancel}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /^cancel$/i }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables Delete and Cancel buttons while deleting", () => {
+    render(
+      <DeleteConfirmDialog
+        open
+        transaction={TRANSACTION}
+        isDeleting
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /^delete$/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /^cancel$/i })).toBeDisabled();
+  });
+
+  it("does not render when open is false", () => {
+    render(
+      <DeleteConfirmDialog
+        open={false}
+        transaction={TRANSACTION}
+        isDeleting={false}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: /^delete$/i })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/transactions/components/DeleteConfirmDialog.tsx
+++ b/frontend/src/features/transactions/components/DeleteConfirmDialog.tsx
@@ -1,0 +1,62 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+import { useCurrency } from "../../../hooks/useCurrency";
+import type { Transaction } from "../../../types/api";
+
+interface DeleteConfirmDialogProps {
+  open: boolean;
+  transaction: Transaction;
+  isDeleting: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function DeleteConfirmDialog({
+  open,
+  transaction,
+  isDeleting,
+  onConfirm,
+  onCancel,
+}: DeleteConfirmDialogProps) {
+  const { formatAmount } = useCurrency();
+
+  return (
+    <AlertDialog open={open}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete this transaction?</AlertDialogTitle>
+        </AlertDialogHeader>
+        <dl className="text-sm">
+          <div className="flex justify-between py-1">
+            <dt className="text-muted-foreground">Date</dt>
+            <dd>{transaction.date}</dd>
+          </div>
+          <div className="flex justify-between py-1">
+            <dt className="text-muted-foreground">Amount</dt>
+            <dd>{formatAmount(Number(transaction.amount))}</dd>
+          </div>
+          <div className="flex justify-between py-1">
+            <dt className="text-muted-foreground">Category</dt>
+            <dd>{transaction.categoryName}</dd>
+          </div>
+        </dl>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={onCancel} disabled={isDeleting}>
+            Cancel
+          </AlertDialogCancel>
+          <AlertDialogAction variant="destructive" onClick={onConfirm} disabled={isDeleting}>
+            Delete
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/frontend/src/features/transactions/components/TransactionFormModal.test.tsx
+++ b/frontend/src/features/transactions/components/TransactionFormModal.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -332,6 +332,84 @@ describe("TransactionFormModal", () => {
       renderModal({ transaction: EDIT_TRANSACTION });
 
       expect(screen.getByRole("button", { name: /delete/i })).toBeInTheDocument();
+    });
+
+    it("opens the delete confirm dialog when the Delete button is clicked", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      renderModal({ transaction: EDIT_TRANSACTION });
+
+      await user.click(screen.getByRole("button", { name: /^delete$/i }));
+
+      expect(await screen.findByRole("alertdialog")).toBeInTheDocument();
+      expect(screen.getByText(/delete this transaction\?/i)).toBeInTheDocument();
+    });
+
+    it("calls DELETE endpoint and closes the modal when delete is confirmed", async () => {
+      let capturedUrl = "";
+      let capturedMethod = "";
+      server.use(
+        http.delete("/api/v1/transactions/:id", ({ request }) => {
+          capturedUrl = request.url;
+          capturedMethod = request.method;
+          return new HttpResponse(null, { status: 204 });
+        }),
+      );
+      const onClose = vi.fn();
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      renderModal({ transaction: EDIT_TRANSACTION, onClose });
+
+      await user.click(screen.getByRole("button", { name: /^delete$/i }));
+      const dialog = await screen.findByRole("alertdialog");
+      await user.click(within(dialog).getByRole("button", { name: /^delete$/i }));
+
+      await waitFor(() => {
+        expect(onClose).toHaveBeenCalled();
+      });
+      expect(capturedMethod).toBe("DELETE");
+      expect(capturedUrl).toContain("/api/v1/transactions/99");
+      expect(await screen.findByText(/transaction deleted/i)).toBeInTheDocument();
+    });
+
+    it("closes the confirm dialog only when delete is canceled", async () => {
+      const onClose = vi.fn();
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      renderModal({ transaction: EDIT_TRANSACTION, onClose });
+
+      await user.click(screen.getByRole("button", { name: /^delete$/i }));
+      const dialog = await screen.findByRole("alertdialog");
+      await user.click(within(dialog).getByRole("button", { name: /^cancel$/i }));
+
+      await waitFor(() => {
+        expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+      });
+      expect(onClose).not.toHaveBeenCalled();
+      expect(screen.getByRole("dialog", { name: /edit transaction/i })).toBeInTheDocument();
+    });
+
+    it("shows an error toast when the DELETE API responds with an error", async () => {
+      server.use(
+        http.delete("/api/v1/transactions/:id", () => {
+          return HttpResponse.json(
+            {
+              type: "about:blank",
+              title: "Not Found",
+              status: 404,
+              detail: "transaction not found",
+            },
+            { status: 404 },
+          );
+        }),
+      );
+      const onClose = vi.fn();
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      renderModal({ transaction: EDIT_TRANSACTION, onClose });
+
+      await user.click(screen.getByRole("button", { name: /^delete$/i }));
+      const dialog = await screen.findByRole("alertdialog");
+      await user.click(within(dialog).getByRole("button", { name: /^delete$/i }));
+
+      expect(await screen.findByText(/transaction not found/i)).toBeInTheDocument();
+      expect(onClose).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/src/features/transactions/components/TransactionFormModal.tsx
+++ b/frontend/src/features/transactions/components/TransactionFormModal.tsx
@@ -31,7 +31,9 @@ import {
 } from "../../../types/api";
 import { useCategories } from "../../categories/api/useCategories";
 import { useCreateTransaction } from "../api/useCreateTransaction";
+import { useDeleteTransaction } from "../api/useDeleteTransaction";
 import { useUpdateTransaction } from "../api/useUpdateTransaction";
+import { DeleteConfirmDialog } from "./DeleteConfirmDialog";
 
 interface TransactionFormModalProps {
   open: boolean;
@@ -126,6 +128,7 @@ export function TransactionFormModal({ open, onClose, transaction }: Transaction
   );
   const [amountError, setAmountError] = useState<string | null>(null);
   const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const amountRef = useRef<HTMLInputElement>(null);
   const initialStateRef = useRef<FormState>(state);
 
@@ -134,11 +137,13 @@ export function TransactionFormModal({ open, onClose, transaction }: Transaction
   const { data: categoriesData } = useCategories();
   const createMutation = useCreateTransaction();
   const updateMutation = useUpdateTransaction(transaction?.id ?? 0);
+  const deleteMutation = useDeleteTransaction();
 
   const resetForm = () => {
     setState(emptyFormState());
     setAmountError(null);
     setShowDiscardConfirm(false);
+    setShowDeleteConfirm(false);
   };
 
   const updateField = <K extends keyof FormState>(key: K, value: FormState[K]) => {
@@ -193,6 +198,25 @@ export function TransactionFormModal({ open, onClose, transaction }: Transaction
   const handleConfirmDiscard = () => {
     resetForm();
     onClose();
+  };
+
+  const handleConfirmDelete = () => {
+    if (!isEditMode) return;
+    deleteMutation.mutate(transaction.id, {
+      onSuccess: () => {
+        showSuccess("Transaction deleted");
+        resetForm();
+        onClose();
+      },
+      onError: (err) => {
+        const message =
+          err instanceof ApiException
+            ? err.apiError.detail
+            : "Failed to delete transaction. Please try again.";
+        showError(message);
+        setShowDeleteConfirm(false);
+      },
+    });
   };
 
   return (
@@ -311,7 +335,16 @@ export function TransactionFormModal({ open, onClose, transaction }: Transaction
             </div>
             <DialogFooter>
               {isEditMode && (
-                <Button type="button" variant="destructive" disabled>
+                <Button
+                  type="button"
+                  variant="destructive"
+                  onClick={() => {
+                    setShowDeleteConfirm(true);
+                  }}
+                  disabled={
+                    createMutation.isPending || updateMutation.isPending || deleteMutation.isPending
+                  }
+                >
                   Delete
                 </Button>
               )}
@@ -319,11 +352,18 @@ export function TransactionFormModal({ open, onClose, transaction }: Transaction
                 type="button"
                 variant="outline"
                 onClick={handleAttemptClose}
-                disabled={createMutation.isPending || updateMutation.isPending}
+                disabled={
+                  createMutation.isPending || updateMutation.isPending || deleteMutation.isPending
+                }
               >
                 Cancel
               </Button>
-              <Button type="submit" disabled={createMutation.isPending || updateMutation.isPending}>
+              <Button
+                type="submit"
+                disabled={
+                  createMutation.isPending || updateMutation.isPending || deleteMutation.isPending
+                }
+              >
                 {createMutation.isPending || updateMutation.isPending ? <Spinner /> : null}
                 Save
               </Button>
@@ -343,6 +383,17 @@ export function TransactionFormModal({ open, onClose, transaction }: Transaction
           setShowDiscardConfirm(false);
         }}
       />
+      {isEditMode && (
+        <DeleteConfirmDialog
+          open={showDeleteConfirm}
+          transaction={transaction}
+          isDeleting={deleteMutation.isPending}
+          onConfirm={handleConfirmDelete}
+          onCancel={() => {
+            setShowDeleteConfirm(false);
+          }}
+        />
+      )}
     </>
   );
 }

--- a/frontend/src/features/transactions/components/TransactionFormModal.tsx
+++ b/frontend/src/features/transactions/components/TransactionFormModal.tsx
@@ -138,6 +138,8 @@ export function TransactionFormModal({ open, onClose, transaction }: Transaction
   const createMutation = useCreateTransaction();
   const updateMutation = useUpdateTransaction(transaction?.id ?? 0);
   const deleteMutation = useDeleteTransaction();
+  const isMutating =
+    createMutation.isPending || updateMutation.isPending || deleteMutation.isPending;
 
   const resetForm = () => {
     setState(emptyFormState());
@@ -341,9 +343,7 @@ export function TransactionFormModal({ open, onClose, transaction }: Transaction
                   onClick={() => {
                     setShowDeleteConfirm(true);
                   }}
-                  disabled={
-                    createMutation.isPending || updateMutation.isPending || deleteMutation.isPending
-                  }
+                  disabled={isMutating}
                 >
                   Delete
                 </Button>
@@ -352,18 +352,11 @@ export function TransactionFormModal({ open, onClose, transaction }: Transaction
                 type="button"
                 variant="outline"
                 onClick={handleAttemptClose}
-                disabled={
-                  createMutation.isPending || updateMutation.isPending || deleteMutation.isPending
-                }
+                disabled={isMutating}
               >
                 Cancel
               </Button>
-              <Button
-                type="submit"
-                disabled={
-                  createMutation.isPending || updateMutation.isPending || deleteMutation.isPending
-                }
-              >
+              <Button type="submit" disabled={isMutating}>
                 {createMutation.isPending || updateMutation.isPending ? <Spinner /> : null}
                 Save
               </Button>

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -58,6 +58,9 @@ export const handlers = [
       updated_at: now,
     });
   }),
+  http.delete("/api/v1/transactions/{id}", ({ response }) => {
+    return response(204).empty();
+  }),
   http.get("/api/v1/categories", ({ response }) => {
     return response(200).json({
       items: [


### PR DESCRIPTION
## 概要

編集モーダル経由の支出削除フローを実装する。Delete ボタンから確認ダイアログを表示し、確認後に物理削除する。

## 変更内容

- `useDeleteTransaction` フックを追加（DELETE /api/v1/transactions/{id}、成功時に `["transactions"]` クエリを invalidate）
- `DeleteConfirmDialog` コンポーネントを追加（対象支出の日付・金額・カテゴリを表示する destructive 確認ダイアログ）
- `TransactionFormModal` の Delete ボタンを有効化し、確認ダイアログ → 削除実行 → モーダル close → "Transaction deleted" トーストのフローを実装
- API エラー時は RFC 9457 Problem Details の `detail` をトースト表示
- MSW デフォルトハンドラに `DELETE /api/v1/transactions/{id}` (204) を追加
- 補助的な refactor として 3 つの mutation の `isPending` 判定を `isMutating` に集約

## 関連 Issue

Closes #253

## スクリーンショット

<!-- frontend/screenshots/ 配下のファイルをドラッグ&ドロップで添付 -->

- `frontend/screenshots/delete-edit-modal-with-delete-button.png` — 編集モーダルの Delete ボタン
<img width="780" height="493" alt="delete-edit-modal-with-delete-button" src="https://github.com/user-attachments/assets/432e2f25-5169-4bbf-94b6-12baf4f4f308" />

- `frontend/screenshots/delete-confirm-dialog.png` — 削除確認ダイアログ
<img width="780" height="493" alt="delete-confirm-dialog" src="https://github.com/user-attachments/assets/991b9f91-523c-4054-9f05-e00e5dcb92af" />

- `frontend/screenshots/delete-success-toast.png` — 削除成功時のトースト
<img width="780" height="493" alt="delete-success-toast" src="https://github.com/user-attachments/assets/ec1b462f-35e3-4607-9ad2-1684d11b2ffc" />

## テスト

- [x] `npm run check` 通過（249 テスト全 pass、E2E、ビルド含む）
- [x] `useDeleteTransaction` の単体テスト（成功時、リクエストパス、クエリ invalidate）
- [x] `DeleteConfirmDialog` の単体テスト（情報表示、ボタン挙動、削除中の disabled 状態）
- [x] `TransactionFormModal` の統合テスト（Delete → 確認ダイアログ → 確認/キャンセル/エラー）
- [x] Playwright MCP で削除フローを手動検証（編集モーダル → 確認ダイアログ → 削除成功トースト）

---
🤖 Generated with [Claude Code](https://claude.ai/code)