### PR TITLE
feat(frontend): 設定画面にアカウント情報・ログアウトを実装

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -28,6 +28,9 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
+      options: --user 1001
     defaults:
       run:
         working-directory: frontend
@@ -57,9 +60,6 @@ jobs:
 
       - name: Build
         run: npm run build
-
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
 
       - name: E2E test (Playwright)
         run: npm run test:e2e

--- a/frontend/src/features/settings/api/useUser.test.tsx
+++ b/frontend/src/features/settings/api/useUser.test.tsx
@@ -1,0 +1,44 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import type { ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+
+import { server } from "../../../test/mocks/server";
+import { useUser } from "./useUser";
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe("useUser", () => {
+  it("returns user when API responds successfully", async () => {
+    server.use(
+      http.get("/api/v1/users/me", () => {
+        return HttpResponse.json({
+          id: 42,
+          email: "user@example.com",
+          display_name: "Example User",
+          created_at: "2026-01-01T00:00:00Z",
+        });
+      }),
+    );
+
+    const { result } = renderHook(() => useUser(), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data).toEqual({
+      id: 42,
+      email: "user@example.com",
+      displayName: "Example User",
+      createdAt: "2026-01-01T00:00:00Z",
+    });
+  });
+});

--- a/frontend/src/features/settings/api/useUser.ts
+++ b/frontend/src/features/settings/api/useUser.ts
@@ -1,0 +1,23 @@
+/**
+ * 認証済みユーザーの情報を取得するフック。
+ *
+ * @see GET /api/v1/users/me
+ */
+
+import { useQuery } from "@tanstack/react-query";
+
+import { apiClient } from "../../../lib/api/client";
+import { UserSchema } from "../../../types/api";
+
+const STALE_TIME_MS = 5 * 60 * 1000;
+
+export function useUser() {
+  return useQuery({
+    queryKey: ["users", "me"],
+    queryFn: async () => {
+      const data = await apiClient.get("/api/v1/users/me");
+      return UserSchema.parse(data);
+    },
+    staleTime: STALE_TIME_MS,
+  });
+}

--- a/frontend/src/features/settings/api/useUser.ts
+++ b/frontend/src/features/settings/api/useUser.ts
@@ -1,7 +1,9 @@
 /**
- * 認証済みユーザーの情報を取得するフック。
+ * 認証済みユーザー情報の取得フック。
  *
- * @see GET /api/v1/users/me
+ * プロフィール変更は稀だが反映遅延を許容しすぎないよう staleTime は 5 分に設定する。
+ *
+ * @see docs/03-design/backend/api-design.md
  */
 
 import { useQuery } from "@tanstack/react-query";

--- a/frontend/src/features/settings/components/SettingsPage.test.tsx
+++ b/frontend/src/features/settings/components/SettingsPage.test.tsx
@@ -1,10 +1,12 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
 import { createMemoryRouter, RouterProvider } from "react-router";
 import { describe, expect, it, vi } from "vitest";
 
-import { routes } from "../../../routes";
+import { server } from "../../../test/mocks/server";
+import SettingsPage from "./SettingsPage";
 
 vi.mock("../../../lib/auth", () => ({
   getToken: vi.fn(() => "existing-token"),
@@ -15,16 +17,25 @@ vi.mock("../../../lib/auth", () => ({
 const { clearToken } = await import("../../../lib/auth");
 const mockClearToken = vi.mocked(clearToken);
 
-function renderSettingsPage() {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
-  });
-  const router = createMemoryRouter(routes, { initialEntries: ["/settings"] });
-  return render(
-    <QueryClientProvider client={queryClient}>
+function renderSettingsPage(queryClient?: QueryClient) {
+  const client =
+    queryClient ??
+    new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+  const router = createMemoryRouter(
+    [
+      { path: "/settings", Component: SettingsPage },
+      { path: "/login", element: <div>Login page</div> },
+    ],
+    { initialEntries: ["/settings"] },
+  );
+  render(
+    <QueryClientProvider client={client}>
       <RouterProvider router={router} />
     </QueryClientProvider>,
   );
+  return { queryClient: client, router };
 }
 
 describe("SettingsPage", () => {
@@ -39,7 +50,7 @@ describe("SettingsPage", () => {
     const user = userEvent.setup();
     mockClearToken.mockClear();
 
-    renderSettingsPage();
+    const { router } = renderSettingsPage();
     await screen.findByText("test@example.com");
 
     await user.click(screen.getByRole("button", { name: /log out/i }));
@@ -47,5 +58,47 @@ describe("SettingsPage", () => {
     await waitFor(() => {
       expect(mockClearToken).toHaveBeenCalledTimes(1);
     });
+    expect(router.state.location.pathname).toBe("/login");
+  });
+
+  it("clears query cache when log out is clicked", async () => {
+    const user = userEvent.setup();
+    mockClearToken.mockClear();
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    queryClient.setQueryData(["transactions", { from: "2026-01-01" }], { items: ["stale"] });
+    queryClient.setQueryData(["analytics"], { stale: true });
+
+    renderSettingsPage(queryClient);
+    await screen.findByText("test@example.com");
+
+    await user.click(screen.getByRole("button", { name: /log out/i }));
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData(["transactions", { from: "2026-01-01" }])).toBeUndefined();
+      expect(queryClient.getQueryData(["analytics"])).toBeUndefined();
+      expect(queryClient.getQueryData(["users", "me"])).toBeUndefined();
+    });
+  });
+
+  it("redirects to login when user query fails", async () => {
+    server.use(
+      http.get("/api/v1/users/me", () =>
+        HttpResponse.json(
+          { type: "about:blank", title: "Internal Server Error", status: 500 },
+          { status: 500 },
+        ),
+      ),
+    );
+    mockClearToken.mockClear();
+
+    const { router } = renderSettingsPage();
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe("/login");
+    });
+    expect(mockClearToken).toHaveBeenCalled();
   });
 });

--- a/frontend/src/features/settings/components/SettingsPage.test.tsx
+++ b/frontend/src/features/settings/components/SettingsPage.test.tsx
@@ -1,12 +1,10 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { http, HttpResponse } from "msw";
 import { createMemoryRouter, RouterProvider } from "react-router";
 import { describe, expect, it, vi } from "vitest";
 
 import { routes } from "../../../routes";
-import { server } from "../../../test/mocks/server";
 
 vi.mock("../../../lib/auth", () => ({
   getToken: vi.fn(() => "existing-token"),
@@ -29,44 +27,20 @@ function renderSettingsPage() {
   );
 }
 
-function mockUserResponse(): void {
-  server.use(
-    http.get("/api/v1/users/me", () => {
-      return HttpResponse.json({
-        id: 1,
-        email: "user@example.com",
-        display_name: "Example User",
-        created_at: "2026-01-01T00:00:00Z",
-      });
-    }),
-  );
-}
-
 describe("SettingsPage", () => {
-  it("renders page heading", () => {
-    mockUserResponse();
-
-    renderSettingsPage();
-
-    expect(screen.getByRole("heading", { level: 1, name: /settings/i })).toBeInTheDocument();
-  });
-
   it("renders user email and display name when user is loaded", async () => {
-    mockUserResponse();
-
     renderSettingsPage();
 
-    expect(await screen.findByText("user@example.com")).toBeInTheDocument();
-    expect(screen.getByText("Example User")).toBeInTheDocument();
+    expect(await screen.findByText("test@example.com")).toBeInTheDocument();
+    expect(screen.getByText("Test User")).toBeInTheDocument();
   });
 
   it("clears token and redirects to login when log out is clicked", async () => {
-    mockUserResponse();
     const user = userEvent.setup();
     mockClearToken.mockClear();
 
     renderSettingsPage();
-    await screen.findByText("user@example.com");
+    await screen.findByText("test@example.com");
 
     await user.click(screen.getByRole("button", { name: /log out/i }));
 

--- a/frontend/src/features/settings/components/SettingsPage.test.tsx
+++ b/frontend/src/features/settings/components/SettingsPage.test.tsx
@@ -2,7 +2,6 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
-import type { ReactNode } from "react";
 import { createMemoryRouter, RouterProvider } from "react-router";
 import { describe, expect, it, vi } from "vitest";
 

--- a/frontend/src/features/settings/components/SettingsPage.test.tsx
+++ b/frontend/src/features/settings/components/SettingsPage.test.tsx
@@ -1,0 +1,78 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import type { ReactNode } from "react";
+import { createMemoryRouter, RouterProvider } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+
+import { routes } from "../../../routes";
+import { server } from "../../../test/mocks/server";
+
+vi.mock("../../../lib/auth", () => ({
+  getToken: vi.fn(() => "existing-token"),
+  setToken: vi.fn(),
+  clearToken: vi.fn(),
+}));
+
+const { clearToken } = await import("../../../lib/auth");
+const mockClearToken = vi.mocked(clearToken);
+
+function renderSettingsPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const router = createMemoryRouter(routes, { initialEntries: ["/settings"] });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  );
+}
+
+function mockUserResponse(): void {
+  server.use(
+    http.get("/api/v1/users/me", () => {
+      return HttpResponse.json({
+        id: 1,
+        email: "user@example.com",
+        display_name: "Example User",
+        created_at: "2026-01-01T00:00:00Z",
+      });
+    }),
+  );
+}
+
+describe("SettingsPage", () => {
+  it("renders page heading", () => {
+    mockUserResponse();
+
+    renderSettingsPage();
+
+    expect(screen.getByRole("heading", { level: 1, name: /settings/i })).toBeInTheDocument();
+  });
+
+  it("renders user email and display name when user is loaded", async () => {
+    mockUserResponse();
+
+    renderSettingsPage();
+
+    expect(await screen.findByText("user@example.com")).toBeInTheDocument();
+    expect(screen.getByText("Example User")).toBeInTheDocument();
+  });
+
+  it("clears token and redirects to login when log out is clicked", async () => {
+    mockUserResponse();
+    const user = userEvent.setup();
+    mockClearToken.mockClear();
+
+    renderSettingsPage();
+    await screen.findByText("user@example.com");
+
+    await user.click(screen.getByRole("button", { name: /log out/i }));
+
+    await waitFor(() => {
+      expect(mockClearToken).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/frontend/src/features/settings/components/SettingsPage.tsx
+++ b/frontend/src/features/settings/components/SettingsPage.tsx
@@ -1,3 +1,63 @@
+import { useNavigate } from "react-router";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Spinner } from "@/components/ui/spinner";
+
+import { clearToken } from "../../../lib/auth";
+import { useUser } from "../api/useUser";
+
 export default function SettingsPage() {
-  return <h1>Settings</h1>;
+  const navigate = useNavigate();
+  const { data: user, isLoading } = useUser();
+
+  const handleLogout = (): void => {
+    clearToken();
+    void navigate("/login", { replace: true });
+  };
+
+  return (
+    <div className="min-h-screen px-4 py-4">
+      <h1 className="font-heading mb-4 text-xl font-semibold">Settings</h1>
+
+      <section aria-label="Account" className="mb-4">
+        <Card>
+          <CardHeader>
+            <h2 className="text-base font-semibold">Account</h2>
+          </CardHeader>
+          <CardContent>
+            {isLoading || !user ? (
+              <div className="flex justify-center py-4">
+                <Spinner aria-label="Loading account" />
+              </div>
+            ) : (
+              <dl className="flex flex-col gap-3">
+                <div>
+                  <dt className="text-muted-foreground text-xs">Email</dt>
+                  <dd className="text-foreground text-sm">{user.email}</dd>
+                </div>
+                <div>
+                  <dt className="text-muted-foreground text-xs">Display Name</dt>
+                  <dd className="text-foreground text-sm">{user.displayName}</dd>
+                </div>
+              </dl>
+            )}
+          </CardContent>
+        </Card>
+      </section>
+
+      <section aria-label="Danger Zone">
+        <Card>
+          <CardHeader>
+            <h2 className="text-base font-semibold">Danger Zone</h2>
+          </CardHeader>
+          <CardContent>
+            <Button variant="outline" onClick={handleLogout}>
+              Log out
+            </Button>
+          </CardContent>
+        </Card>
+      </section>
+    </div>
+  );
 }

--- a/frontend/src/features/settings/components/SettingsPage.tsx
+++ b/frontend/src/features/settings/components/SettingsPage.tsx
@@ -1,3 +1,5 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect } from "react";
 import { useNavigate } from "react-router";
 
 import { Button } from "@/components/ui/button";
@@ -9,10 +11,23 @@ import { useUser } from "../api/useUser";
 
 export default function SettingsPage() {
   const navigate = useNavigate();
-  const { data: user, isLoading } = useUser();
+  const queryClient = useQueryClient();
+  const { data: user, isLoading, isError } = useUser();
+
+  // useUser が失敗するのは主にトークン期限切れ（401）。AuthGuard はマウント時にしか
+  // トークンを検査しないため、ここでクリアしてログイン画面へ送らないと
+  // スピナー表示のまま画面から抜けられなくなる。
+  useEffect(() => {
+    if (isError) {
+      clearToken();
+      queryClient.clear();
+      void navigate("/login", { replace: true });
+    }
+  }, [isError, navigate, queryClient]);
 
   const handleLogout = (): void => {
     clearToken();
+    queryClient.clear();
     void navigate("/login", { replace: true });
   };
 

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -23,6 +23,14 @@ export const handlers = [
       },
     });
   }),
+  http.get("/api/v1/users/me", ({ response }) => {
+    return response(200).json({
+      id: 1,
+      email: "test@example.com",
+      display_name: "Test User",
+      created_at: "2026-01-01T00:00:00Z",
+    });
+  }),
   http.get("/api/v1/transactions", ({ response }) => {
     return response(200).json({ items: [] });
   }),


### PR DESCRIPTION
## 概要
設定画面に認証済みユーザーのアカウント情報表示と、ログアウト機能を追加する。

## 変更内容
- `useUser` フックを追加し、`GET /api/v1/users/me` で取得したユーザー情報を 5 分間キャッシュ
- `SettingsPage` に Account / Danger Zone セクションを実装（メール・表示名の表示、Log out ボタン）
- ログアウト時に JWT を破棄して `/login` へリダイレクト
- MSW のデフォルトハンドラに `/api/v1/users/me` を追加
- `useUser` / `SettingsPage` の Vitest テストを追加

## 関連 Issue
Closes #256

## スクリーンショット
 frontend/screenshots/settings-account-loaded.png
<img width="390" height="844" alt="settings-account-loaded" src="https://github.com/user-attachments/assets/205acf9c-6b34-4483-8e1e-d42f917f7401" />

frontend/screenshots/settings-after-logout.png 
<img width="390" height="844" alt="settings-after-logout" src="https://github.com/user-attachments/assets/54789f20-9fa2-4e53-a34f-3259756892dd" />

## テスト
- [x] `npm test` — useUser / SettingsPage の単体テストがパス
- [x] Playwright MCP で画面表示・ログアウト動作を目視確認

---
🤖 Generated with [Claude Code](https://claude.ai/code)