### PR TITLE
feat(frontend): 設定画面に通貨選択機能を追加

### DIFF
--- a/frontend/src/components/ui/radio-group.tsx
+++ b/frontend/src/components/ui/radio-group.tsx
@@ -1,0 +1,42 @@
+import * as React from "react";
+import { RadioGroup as RadioGroupPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function RadioGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Root>) {
+  return (
+    <RadioGroupPrimitive.Root
+      data-slot="radio-group"
+      className={cn("grid w-full gap-2", className)}
+      {...props}
+    />
+  );
+}
+
+function RadioGroupItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Item>) {
+  return (
+    <RadioGroupPrimitive.Item
+      data-slot="radio-group-item"
+      className={cn(
+        "group/radio-group-item peer border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary relative flex aspect-square size-4 shrink-0 rounded-full border outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:ring-3 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:ring-3",
+        className,
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator
+        data-slot="radio-group-indicator"
+        className="flex size-4 items-center justify-center"
+      >
+        <span className="bg-primary-foreground absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2 rounded-full" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  );
+}
+
+export { RadioGroup, RadioGroupItem };

--- a/frontend/src/features/settings/components/CurrencySelector.test.tsx
+++ b/frontend/src/features/settings/components/CurrencySelector.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { CurrencySelector } from "./CurrencySelector";
+
+const STORAGE_KEY = "expense-tracker:currency";
+
+describe("CurrencySelector", () => {
+  beforeEach(() => {
+    localStorage.setItem(STORAGE_KEY, "JPY");
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("renders current currency with symbol", () => {
+    render(<CurrencySelector />);
+
+    expect(screen.getByRole("button", { name: /currency/i })).toHaveTextContent("JPY (¥)");
+  });
+
+  it("opens currency selection dialog when trigger is clicked", async () => {
+    const user = userEvent.setup();
+    render(<CurrencySelector />);
+
+    await user.click(screen.getByRole("button", { name: /currency/i }));
+
+    expect(screen.getByRole("dialog", { name: /select currency/i })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /JPY/ })).toBeChecked();
+    expect(screen.getByRole("radio", { name: /USD/ })).toBeInTheDocument();
+  });
+
+  it("shows confirmation dialog when a different currency is selected", async () => {
+    const user = userEvent.setup();
+    render(<CurrencySelector />);
+
+    await user.click(screen.getByRole("button", { name: /currency/i }));
+    await user.click(screen.getByRole("radio", { name: /USD/ }));
+
+    expect(
+      screen.getByText(/changing currency only affects how amounts are displayed/i),
+    ).toBeInTheDocument();
+  });
+
+  it("persists new currency to localStorage when confirmed", async () => {
+    const user = userEvent.setup();
+    render(<CurrencySelector />);
+
+    await user.click(screen.getByRole("button", { name: /currency/i }));
+    await user.click(screen.getByRole("radio", { name: /USD/ }));
+    await user.click(screen.getByRole("button", { name: /change/i }));
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("USD");
+    expect(screen.getByRole("button", { name: /currency/i })).toHaveTextContent("USD ($)");
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("does not persist new currency when cancelled", async () => {
+    const user = userEvent.setup();
+    render(<CurrencySelector />);
+
+    await user.click(screen.getByRole("button", { name: /currency/i }));
+    await user.click(screen.getByRole("radio", { name: /USD/ }));
+    await user.click(screen.getByRole("button", { name: /keep current/i }));
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("JPY");
+    expect(screen.getByRole("dialog", { name: /select currency/i })).toBeInTheDocument();
+  });
+
+  it("closes selection dialog without confirmation when current currency is selected", async () => {
+    const user = userEvent.setup();
+    render(<CurrencySelector />);
+
+    await user.click(screen.getByRole("button", { name: /currency/i }));
+    await user.click(screen.getByRole("radio", { name: /JPY/ }));
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("JPY");
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/settings/components/CurrencySelector.tsx
+++ b/frontend/src/features/settings/components/CurrencySelector.tsx
@@ -3,23 +3,17 @@ import { useId, useState } from "react";
 
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { Modal } from "@/components/Modal";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { useCurrency } from "@/hooks/useCurrency";
 import { getCurrencySymbol, SUPPORTED_CURRENCIES } from "@/lib/currency";
 import { cn } from "@/lib/utils";
 
 export function CurrencySelector() {
-  const radioGroupName = useId();
+  const idPrefix = useId();
   const { currency, setCurrency } = useCurrency();
   const [isPickerOpen, setIsPickerOpen] = useState(false);
   const [pendingCurrency, setPendingCurrency] = useState<string | null>(null);
-
-  const handleSelect = (next: string): void => {
-    if (next === currency) {
-      setIsPickerOpen(false);
-      return;
-    }
-    setPendingCurrency(next);
-  };
 
   const handleConfirmChange = (): void => {
     if (pendingCurrency === null) return;
@@ -51,35 +45,38 @@ export function CurrencySelector() {
         }}
         title="Select currency"
       >
-        <ul className="flex flex-col">
+        <RadioGroup
+          value={currency}
+          onValueChange={(next) => {
+            setPendingCurrency(next);
+          }}
+        >
           {SUPPORTED_CURRENCIES.map((code) => {
             const checked = code === currency;
+            const id = `${idPrefix}-${code}`;
             return (
-              <li key={code}>
-                <label
-                  className={cn(
-                    "hover:bg-muted/50 flex cursor-pointer items-center justify-between rounded-md px-2 py-2 text-sm",
-                    checked && "bg-muted/30",
-                  )}
-                >
-                  <span className="flex items-center gap-2">
-                    <input
-                      type="radio"
-                      name={radioGroupName}
-                      value={code}
-                      checked={checked}
-                      readOnly
-                      onClick={() => {
-                        handleSelect(code);
-                      }}
-                    />
-                    {code} ({getCurrencySymbol(code)})
-                  </span>
-                </label>
-              </li>
+              <Label
+                key={code}
+                htmlFor={id}
+                className={cn(
+                  "hover:bg-muted/50 cursor-pointer rounded-md px-2 py-2 font-normal",
+                  checked && "bg-muted/30",
+                )}
+              >
+                <RadioGroupItem
+                  value={code}
+                  id={id}
+                  onClick={() => {
+                    if (checked) setIsPickerOpen(false);
+                  }}
+                />
+                <span>
+                  {code} ({getCurrencySymbol(code)})
+                </span>
+              </Label>
             );
           })}
-        </ul>
+        </RadioGroup>
       </Modal>
 
       <ConfirmDialog

--- a/frontend/src/features/settings/components/CurrencySelector.tsx
+++ b/frontend/src/features/settings/components/CurrencySelector.tsx
@@ -1,0 +1,98 @@
+import { ChevronRight } from "lucide-react";
+import { useId, useState } from "react";
+
+import { ConfirmDialog } from "@/components/ConfirmDialog";
+import { Modal } from "@/components/Modal";
+import { useCurrency } from "@/hooks/useCurrency";
+import { getCurrencySymbol, SUPPORTED_CURRENCIES } from "@/lib/currency";
+import { cn } from "@/lib/utils";
+
+export function CurrencySelector() {
+  const radioGroupName = useId();
+  const { currency, setCurrency } = useCurrency();
+  const [isPickerOpen, setIsPickerOpen] = useState(false);
+  const [pendingCurrency, setPendingCurrency] = useState<string | null>(null);
+
+  const handleSelect = (next: string): void => {
+    if (next === currency) {
+      setIsPickerOpen(false);
+      return;
+    }
+    setPendingCurrency(next);
+  };
+
+  const handleConfirmChange = (): void => {
+    if (pendingCurrency === null) return;
+    setCurrency(pendingCurrency);
+    setPendingCurrency(null);
+    setIsPickerOpen(false);
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => {
+          setIsPickerOpen(true);
+        }}
+        className="hover:bg-muted/50 flex w-full items-center justify-between rounded-md py-2 text-left text-sm"
+      >
+        <span className="font-medium">Currency</span>
+        <span className="text-muted-foreground flex items-center gap-1">
+          {currency} ({getCurrencySymbol(currency)})
+          <ChevronRight className="size-4" />
+        </span>
+      </button>
+
+      <Modal
+        open={isPickerOpen}
+        onClose={() => {
+          setIsPickerOpen(false);
+        }}
+        title="Select currency"
+      >
+        <ul className="flex flex-col">
+          {SUPPORTED_CURRENCIES.map((code) => {
+            const checked = code === currency;
+            return (
+              <li key={code}>
+                <label
+                  className={cn(
+                    "hover:bg-muted/50 flex cursor-pointer items-center justify-between rounded-md px-2 py-2 text-sm",
+                    checked && "bg-muted/30",
+                  )}
+                >
+                  <span className="flex items-center gap-2">
+                    <input
+                      type="radio"
+                      name={radioGroupName}
+                      value={code}
+                      checked={checked}
+                      readOnly
+                      onClick={() => {
+                        handleSelect(code);
+                      }}
+                    />
+                    {code} ({getCurrencySymbol(code)})
+                  </span>
+                </label>
+              </li>
+            );
+          })}
+        </ul>
+      </Modal>
+
+      <ConfirmDialog
+        open={pendingCurrency !== null}
+        title="Change display currency?"
+        message="Changing currency only affects how amounts are displayed. Existing data will not be converted."
+        confirmLabel="Change"
+        cancelLabel="Keep current"
+        onConfirm={handleConfirmChange}
+        onCancel={() => {
+          setPendingCurrency(null);
+        }}
+      />
+    </>
+  );
+}

--- a/frontend/src/features/settings/components/SettingsPage.tsx
+++ b/frontend/src/features/settings/components/SettingsPage.tsx
@@ -8,6 +8,7 @@ import { Spinner } from "@/components/ui/spinner";
 
 import { clearToken } from "../../../lib/auth";
 import { useUser } from "../api/useUser";
+import { CurrencySelector } from "./CurrencySelector";
 
 export default function SettingsPage() {
   const navigate = useNavigate();
@@ -57,6 +58,17 @@ export default function SettingsPage() {
                 </div>
               </dl>
             )}
+          </CardContent>
+        </Card>
+      </section>
+
+      <section aria-label="Preferences" className="mb-4">
+        <Card>
+          <CardHeader>
+            <h2 className="text-base font-semibold">Preferences</h2>
+          </CardHeader>
+          <CardContent>
+            <CurrencySelector />
           </CardContent>
         </Card>
       </section>

--- a/frontend/src/lib/currency.test.ts
+++ b/frontend/src/lib/currency.test.ts
@@ -5,6 +5,7 @@ import {
   formatCurrency,
   getCurrencyDecimalDigits,
   getCurrencySymbol,
+  REGION_TO_CURRENCY,
   SUPPORTED_CURRENCIES,
 } from "./currency";
 
@@ -78,13 +79,11 @@ describe("getCurrencySymbol", () => {
 });
 
 describe("SUPPORTED_CURRENCIES", () => {
-  it("contains JPY, USD, EUR as common currencies", () => {
-    expect(SUPPORTED_CURRENCIES).toContain("JPY");
-    expect(SUPPORTED_CURRENCIES).toContain("USD");
-    expect(SUPPORTED_CURRENCIES).toContain("EUR");
-  });
+  it("includes every currency that detectCurrencyFromLocale can return", () => {
+    const detectable = new Set(Object.values(REGION_TO_CURRENCY));
+    const supported = new Set<string>(SUPPORTED_CURRENCIES);
+    const missing = [...detectable].filter((code) => !supported.has(code));
 
-  it("has unique currency codes", () => {
-    expect(new Set(SUPPORTED_CURRENCIES).size).toBe(SUPPORTED_CURRENCIES.length);
+    expect(missing).toEqual([]);
   });
 });

--- a/frontend/src/lib/currency.test.ts
+++ b/frontend/src/lib/currency.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { detectCurrencyFromLocale, formatCurrency, getCurrencyDecimalDigits } from "./currency";
+import {
+  detectCurrencyFromLocale,
+  formatCurrency,
+  getCurrencyDecimalDigits,
+  getCurrencySymbol,
+  SUPPORTED_CURRENCIES,
+} from "./currency";
 
 describe("detectCurrencyFromLocale", () => {
   it.each([
@@ -57,5 +63,28 @@ describe("formatCurrency", () => {
 
   it("formats USD rounding to two decimal places", () => {
     expect(formatCurrency(12.5, "USD", "en-US")).toBe("$12.50");
+  });
+});
+
+describe("getCurrencySymbol", () => {
+  it.each([
+    ["JPY", "¥"],
+    ["USD", "$"],
+    ["EUR", "€"],
+    ["GBP", "£"],
+  ])("returns %s symbol for %s", (currency, expected) => {
+    expect(getCurrencySymbol(currency, "en-US")).toBe(expected);
+  });
+});
+
+describe("SUPPORTED_CURRENCIES", () => {
+  it("contains JPY, USD, EUR as common currencies", () => {
+    expect(SUPPORTED_CURRENCIES).toContain("JPY");
+    expect(SUPPORTED_CURRENCIES).toContain("USD");
+    expect(SUPPORTED_CURRENCIES).toContain("EUR");
+  });
+
+  it("has unique currency codes", () => {
+    expect(new Set(SUPPORTED_CURRENCIES).size).toBe(SUPPORTED_CURRENCIES.length);
   });
 });

--- a/frontend/src/lib/currency.ts
+++ b/frontend/src/lib/currency.ts
@@ -5,7 +5,7 @@
  * @see docs/03-design/backend/domain-model.md
  */
 
-const REGION_TO_CURRENCY: Record<string, string> = {
+export const REGION_TO_CURRENCY: Record<string, string> = {
   JP: "JPY",
   US: "USD",
   GB: "GBP",

--- a/frontend/src/lib/currency.ts
+++ b/frontend/src/lib/currency.ts
@@ -40,6 +40,28 @@ const REGION_TO_CURRENCY: Record<string, string> = {
 
 const FALLBACK_CURRENCY = "USD";
 
+export const SUPPORTED_CURRENCIES = [
+  "JPY",
+  "USD",
+  "EUR",
+  "GBP",
+  "AUD",
+  "CAD",
+  "CHF",
+  "CNY",
+  "HKD",
+  "TWD",
+  "KRW",
+  "SGD",
+  "NZD",
+  "SEK",
+  "NOK",
+  "DKK",
+  "INR",
+  "BRL",
+  "MXN",
+] as const;
+
 export function detectCurrencyFromLocale(locale: string): string {
   try {
     const region = new Intl.Locale(locale).maximize().region;
@@ -66,6 +88,11 @@ export function getCurrencyFormatter(currency: string, locale?: string): Intl.Nu
 
 export function getCurrencyDecimalDigits(currency: string): number {
   return getCurrencyFormatter(currency).resolvedOptions().maximumFractionDigits ?? 2;
+}
+
+export function getCurrencySymbol(currency: string, locale?: string): string {
+  const parts = getCurrencyFormatter(currency, locale).formatToParts(0);
+  return parts.find((part) => part.type === "currency")?.value ?? currency;
 }
 
 export function formatCurrency(amount: number, currency: string, locale?: string): string {


### PR DESCRIPTION
## 概要
設定画面に Preferences セクションを追加し、ユーザーが表示通貨を JPY / USD / EUR から選択できるようにした。

## 変更内容
- 通貨ユーティリティ（`SUPPORTED_CURRENCIES` / `getCurrencySymbol`）を追加
- `CurrencySelector` コンポーネントを実装し、shadcn/ui の `RadioGroup` を採用
- 設定画面に Preferences セクションを追加し `CurrencySelector` を組み込み
- 通貨リストとシンボルマップの整合性を担保するガードテストを追加

## 関連 Issue
Closes #257

## スクリーンショット
- frontend/screenshots/settings-currency-default.png
<img width="390" height="844" alt="settings-currency-default" src="https://github.com/user-attachments/assets/16ee37bb-5cfb-41cf-ab71-8360c69d572c" />

- frontend/screenshots/settings-currency-picker.png
<img width="390" height="844" alt="settings-currency-picker" src="https://github.com/user-attachments/assets/930244d3-ccd5-4736-b61b-dba142e512fd" />

- frontend/screenshots/settings-currency-confirm.png
<img width="390" height="844" alt="settings-currency-confirm" src="https://github.com/user-attachments/assets/9f54507a-901e-42e4-b5ef-960bd3143866" />

- frontend/screenshots/settings-currency-after-change.png
<img width="390" height="844" alt="settings-currency-after-change" src="https://github.com/user-attachments/assets/cdd94e9a-f835-49e1-8748-16ffb6b51a91" />

- frontend/screenshots/settings-currency-after-cancel.png
<img width="390" height="844" alt="settings-currency-after-cancel" src="https://github.com/user-attachments/assets/53474b69-7f4a-43a5-9052-40c31f6da917" />

## テスト
- [x] `npm test` で `CurrencySelector` および通貨ユーティリティのテストが通ることを確認
- [x] Playwright MCP で通貨選択 → 確認 → キャンセル / 適用 フローを目視確認

---
🤖 Generated with [Claude Code](https://claude.ai/code)