### PR TITLE
chore: Playwright MCP のサーバ起動/停止手順を統一する

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -57,7 +57,7 @@ Vite の mode ベースで環境ごとに `.env.*` を分割する。Vite が `-
 | ファイル | git | 用途 |
 |---|---|---|
 | `.env.example` | コミット | 公開キーのテンプレート。新規セットアップ時に `.env.development.local` 等にコピーして実値を埋める |
-| `.env.e2e` | コミット | E2E (`npm run build:e2e` = `vite build --mode e2e`) 専用の値 |
+| `.env.e2e` | コミット | E2E ビルド (`npm run build:e2e` = `vite build --mode e2e`) と Playwright MCP 検証用 dev サーバ (`npm run dev:e2e` = `vite --mode e2e`) 専用の値 |
 | `.env*.local` | 無視 | 個別開発者の実値・本番シークレット |
 
 - `VITE_` プレフィックスのキーのみ `import.meta.env` 経由でクライアントから参照できる。シークレットを誤って公開しないよう、機密値は `VITE_` を付けず BE 側で扱う

--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -224,7 +224,18 @@ it("sets hasError state to true", () => {
 
 UI を実装・修正する際は、自動テストとは別に画面を実際にレンダリングして見た目と挙動を確認する。
 
-- 開発サーバー（`npm run dev`）を起動し、Playwright MCP（`mcp__playwright__browser_*`）で対象画面を操作・キャプチャする
+### 開発サーバーの起動・停止
+
+検証用の開発サーバーは `npm run dev:e2e`（= `vite --mode e2e`）を使う。MSW でバックエンドをモックし、`.env.e2e` の dummy GSI client_id でログイン画面も描画できる。
+
+- **起動**: Bash を `run_in_background: true` で `cd frontend && npm run dev:e2e` 実行
+- **停止**: Claude 組み込みの **TaskStop**（バックグラウンドタスクを task_id で停止する組み込みツール）で停止する。Bash を経由しないので承認プロンプトが発生しない
+- env 値は `.env.e2e` に閉じている。`VITE_*` をコマンドラインで上書きしない（揺れの原因になる）
+- `pkill` / `kill` / `lsof` でプロセスを探して落とす運用は禁止。必ず TaskStop を使う
+
+### Playwright MCP での操作・キャプチャ
+
+- Playwright MCP（`mcp__playwright__browser_*`）で対象画面を操作・キャプチャする
 - スクリーンショットは `frontend/screenshots/` に保存する（このディレクトリは `.gitignore` 管理。Git にはコミットしない）
 - ファイル名は内容がわかる名前にする（例: `transaction-list-empty.png`, `login-error-422.png`）
 - 検証対象はゴールデンパス＋主要なエッジケース（空状態・エラー表示・ローディング・レスポンシブの主要ブレークポイント）

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:e2e": "vite --mode e2e",
     "build": "vite build",
     "preview": "vite preview",
     "lint:fix": "eslint . --fix",


### PR DESCRIPTION
## 概要

Playwright MCP で画面検証する際、開発サーバーの起動/停止コマンドが揺れて承認プロンプトが頻発していた問題を解消する。`.claude/settings.local.json` に散らかっていた `pkill -f "vite..."` / `kill ...` / `lsof *` 系のエントリも整理対象とした。

## 変更内容

- `frontend/package.json` に `dev:e2e` スクリプト（`vite --mode e2e`）を追加。env 値はすべて既存の `.env.e2e` に閉じる（コマンドラインへの env ハードコード不要）
- `.claude/rules/frontend.md` の「画面検証」セクションを再構成し、起動/停止手順を統一
  - 起動: Bash を `run_in_background: true` で `cd frontend && npm run dev:e2e`
  - 停止: Claude 組み込みの **TaskStop**（バックグラウンドタスクを task_id で停止）。Bash 経由ではないため承認プロンプトが発生しない
  - `pkill` / `kill` / `lsof` でのプロセス停止は禁止と明示
- `.claude/rules/frontend.md` の「環境変数」セクションで `.env.e2e` の用途欄に `dev:e2e` も追記し、build と dev の両方で使われることを明記
- 既存の `Bash(npm run *)` 権限で吸収できるため `.claude/settings.local.json` への追加権限は不要

## 関連 Issue

Closes #319

## テスト

- [x] Playwright MCP で `npm run dev:e2e` をバックグラウンド起動 → `localhost:5174` にナビゲートしてログイン画面が描画されることを確認（MSW + dummy GSI 動作）
- [x] TaskStop で停止し、承認プロンプトが発生しないことを確認
- [x] `npm run check` 通過（Prettier ✓ / ESLint ✓ / tsc ✓ / Vitest 294/294 ✓ / Playwright 2/2 ✓ / Vite build ✓）

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)