### PR TITLE
feat: 422 バリデーションエラーをフォームのインラインエラーとして表示

### DIFF
--- a/frontend/src/features/transactions/components/TransactionFormModal.test.tsx
+++ b/frontend/src/features/transactions/components/TransactionFormModal.test.tsx
@@ -237,6 +237,7 @@ describe("TransactionFormModal", () => {
       setUpValidationErrorHandler([
         { pointer: "#/amount", detail: "must be greater than 0" },
         { pointer: "#/category_id", detail: "category not found" },
+        { pointer: "#/need_want_type", detail: "need_want_type is required" },
       ]);
       const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
       renderModal();
@@ -244,9 +245,13 @@ describe("TransactionFormModal", () => {
       await user.type(screen.getByLabelText(/amount/i), "10");
       await user.click(screen.getByRole("button", { name: /save/i }));
 
-      expect(await screen.findByText(/must be greater than 0/i)).toBeInTheDocument();
+      const needWantError = await screen.findByText(/need_want_type is required/i);
+      expect(screen.getByText(/must be greater than 0/i)).toBeInTheDocument();
       expect(screen.getByText(/category not found/i)).toBeInTheDocument();
       expect(screen.getByLabelText(/amount/i)).toHaveAttribute("aria-invalid", "true");
+      const toggleGroup = screen.getByRole("group");
+      expect(toggleGroup).toHaveAttribute("aria-invalid", "true");
+      expect(toggleGroup.getAttribute("aria-describedby")).toBe(needWantError.id);
     });
 
     it("does not show a toast when inline field errors are present", async () => {

--- a/frontend/src/features/transactions/components/TransactionFormModal.test.tsx
+++ b/frontend/src/features/transactions/components/TransactionFormModal.test.tsx
@@ -190,7 +190,7 @@ describe("TransactionFormModal", () => {
     });
   });
 
-  it("shows an error toast when the API responds with an error", async () => {
+  it("shows an error toast when the API returns 422 without a field errors array", async () => {
     server.use(
       http.post("/api/v1/transactions", () => {
         return HttpResponse.json(
@@ -213,6 +213,70 @@ describe("TransactionFormModal", () => {
 
     expect(await screen.findByText(/amount must be positive/i)).toBeInTheDocument();
     expect(onClose).not.toHaveBeenCalled();
+  });
+
+  describe("422 with field errors", () => {
+    function setUpValidationErrorHandler(errors: { pointer: string; detail: string }[]) {
+      server.use(
+        http.post("/api/v1/transactions", () => {
+          return HttpResponse.json(
+            {
+              type: "/errors/validation-error",
+              title: "Your request is not valid.",
+              status: 422,
+              detail: "One or more fields have validation errors.",
+              errors,
+            },
+            { status: 422 },
+          );
+        }),
+      );
+    }
+
+    it("renders inline errors under the corresponding fields", async () => {
+      setUpValidationErrorHandler([
+        { pointer: "#/amount", detail: "must be greater than 0" },
+        { pointer: "#/category_id", detail: "category not found" },
+      ]);
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      renderModal();
+
+      await user.type(screen.getByLabelText(/amount/i), "10");
+      await user.click(screen.getByRole("button", { name: /save/i }));
+
+      expect(await screen.findByText(/must be greater than 0/i)).toBeInTheDocument();
+      expect(screen.getByText(/category not found/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/amount/i)).toHaveAttribute("aria-invalid", "true");
+    });
+
+    it("does not show a toast when inline field errors are present", async () => {
+      setUpValidationErrorHandler([{ pointer: "#/amount", detail: "must be greater than 0" }]);
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      renderModal();
+
+      await user.type(screen.getByLabelText(/amount/i), "10");
+      await user.click(screen.getByRole("button", { name: /save/i }));
+
+      const inlineMessages = await screen.findAllByText(/must be greater than 0/i);
+      expect(inlineMessages).toHaveLength(1);
+    });
+
+    it("clears the inline error for a field when its input changes", async () => {
+      setUpValidationErrorHandler([
+        { pointer: "#/title", detail: "must be at most 200 characters" },
+      ]);
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      renderModal();
+
+      await user.type(screen.getByLabelText(/amount/i), "10");
+      await user.click(screen.getByRole("button", { name: /save/i }));
+
+      expect(await screen.findByText(/must be at most 200 characters/i)).toBeInTheDocument();
+
+      await user.type(screen.getByLabelText(/title/i), "shorter");
+
+      expect(screen.queryByText(/must be at most 200 characters/i)).not.toBeInTheDocument();
+    });
   });
 
   it("closes immediately when cancel is clicked with no input changes", async () => {

--- a/frontend/src/features/transactions/components/TransactionFormModal.tsx
+++ b/frontend/src/features/transactions/components/TransactionFormModal.tsx
@@ -323,6 +323,8 @@ export function TransactionFormModal({ open, onClose, transaction }: Transaction
                 }}
                 className="self-start"
                 rovingFocus={false}
+                aria-invalid={needWantError !== undefined}
+                aria-describedby={needWantError !== undefined ? `${needWantId}-error` : undefined}
               >
                 {NeedWantTypeSchema.options.map((value) => (
                   <ToggleGroupItem key={value} value={value} aria-label={value}>

--- a/frontend/src/features/transactions/components/TransactionFormModal.tsx
+++ b/frontend/src/features/transactions/components/TransactionFormModal.tsx
@@ -153,7 +153,7 @@ export function TransactionFormModal({ open, onClose, transaction }: Transaction
 
   const updateField = <K extends keyof FormState>(key: K, value: FormState[K]) => {
     setState((prev) => ({ ...prev, [key]: value }));
-    if (key in fieldErrors) clearFieldError(key);
+    clearFieldError(key);
   };
 
   const handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {

--- a/frontend/src/features/transactions/components/TransactionFormModal.tsx
+++ b/frontend/src/features/transactions/components/TransactionFormModal.tsx
@@ -19,9 +19,9 @@ import { Textarea } from "@/components/ui/textarea";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 
 import { ConfirmDialog } from "../../../components/ConfirmDialog";
+import { useApiError } from "../../../hooks/useApiError";
 import { useCurrency } from "../../../hooks/useCurrency";
 import { useToast } from "../../../hooks/useToast";
-import { ApiException } from "../../../lib/api/errors";
 import { todayIsoDate } from "../../../lib/isoDate";
 import {
   NeedWantTypeSchema,
@@ -119,7 +119,8 @@ export function TransactionFormModal({ open, onClose, transaction }: Transaction
   const isEditMode = transaction !== undefined;
   const dateId = useId();
   const amountId = useId();
-  const categoryId = useId();
+  const categoryFieldId = useId();
+  const needWantId = useId();
   const titleId = useId();
   const memoId = useId();
 
@@ -133,7 +134,8 @@ export function TransactionFormModal({ open, onClose, transaction }: Transaction
   const initialStateRef = useRef<FormState>(state);
 
   const { decimalDigits } = useCurrency();
-  const { showSuccess, showError } = useToast();
+  const { showSuccess } = useToast();
+  const { fieldErrors, handleError, clearFieldError, clearAllFieldErrors } = useApiError();
   const { data: categoriesData } = useCategories();
   const createMutation = useCreateTransaction();
   const updateMutation = useUpdateTransaction(transaction?.id ?? 0);
@@ -146,10 +148,12 @@ export function TransactionFormModal({ open, onClose, transaction }: Transaction
     setAmountError(null);
     setShowDiscardConfirm(false);
     setShowDeleteConfirm(false);
+    clearAllFieldErrors();
   };
 
   const updateField = <K extends keyof FormState>(key: K, value: FormState[K]) => {
     setState((prev) => ({ ...prev, [key]: value }));
+    if (key in fieldErrors) clearFieldError(key);
   };
 
   const handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
@@ -160,13 +164,7 @@ export function TransactionFormModal({ open, onClose, transaction }: Transaction
       return;
     }
     setAmountError(null);
-    const onError = (err: Error) => {
-      const message =
-        err instanceof ApiException
-          ? err.apiError.detail
-          : "Failed to save transaction. Please try again.";
-      showError(message);
-    };
+    clearAllFieldErrors();
     if (isEditMode) {
       updateMutation.mutate(buildRequest(state), {
         onSuccess: () => {
@@ -174,7 +172,7 @@ export function TransactionFormModal({ open, onClose, transaction }: Transaction
           resetForm();
           onClose();
         },
-        onError,
+        onError: handleError,
       });
     } else {
       createMutation.mutate(buildRequest(state), {
@@ -183,7 +181,7 @@ export function TransactionFormModal({ open, onClose, transaction }: Transaction
           resetForm();
           onClose();
         },
-        onError,
+        onError: handleError,
       });
     }
   };
@@ -211,15 +209,18 @@ export function TransactionFormModal({ open, onClose, transaction }: Transaction
         onClose();
       },
       onError: (err) => {
-        const message =
-          err instanceof ApiException
-            ? err.apiError.detail
-            : "Failed to delete transaction. Please try again.";
-        showError(message);
+        handleError(err);
         setShowDeleteConfirm(false);
       },
     });
   };
+
+  const dateError = fieldErrors.date;
+  const amountInlineError = amountError ?? fieldErrors.amount ?? null;
+  const categoryError = fieldErrors.categoryId;
+  const needWantError = fieldErrors.needWantType;
+  const titleError = fieldErrors.title;
+  const memoError = fieldErrors.memo;
 
   return (
     <>
@@ -246,10 +247,17 @@ export function TransactionFormModal({ open, onClose, transaction }: Transaction
                 type="date"
                 value={state.date}
                 required
+                aria-invalid={dateError !== undefined}
+                aria-describedby={dateError !== undefined ? `${dateId}-error` : undefined}
                 onChange={(event) => {
                   updateField("date", event.target.value);
                 }}
               />
+              {dateError !== undefined && (
+                <p id={`${dateId}-error`} className="text-destructive text-xs">
+                  {dateError}
+                </p>
+              )}
             </div>
             <div className="flex flex-col gap-1.5">
               <Label htmlFor={amountId}>Amount</Label>
@@ -259,24 +267,28 @@ export function TransactionFormModal({ open, onClose, transaction }: Transaction
                 type="text"
                 inputMode="decimal"
                 value={state.amount}
-                aria-invalid={amountError !== null}
-                aria-describedby={amountError !== null ? `${amountId}-error` : undefined}
+                aria-invalid={amountInlineError !== null}
+                aria-describedby={amountInlineError !== null ? `${amountId}-error` : undefined}
                 onChange={(event) => {
                   updateField("amount", event.target.value);
                   if (amountError !== null) setAmountError(null);
                 }}
               />
-              {amountError !== null && (
+              {amountInlineError !== null && (
                 <p id={`${amountId}-error`} className="text-destructive text-xs">
-                  {amountError}
+                  {amountInlineError}
                 </p>
               )}
             </div>
             <div className="flex flex-col gap-1.5">
-              <Label htmlFor={categoryId}>Category</Label>
+              <Label htmlFor={categoryFieldId}>Category</Label>
               <select
-                id={categoryId}
+                id={categoryFieldId}
                 value={state.categoryId ?? ""}
+                aria-invalid={categoryError !== undefined}
+                aria-describedby={
+                  categoryError !== undefined ? `${categoryFieldId}-error` : undefined
+                }
                 className="border-input bg-background h-9 rounded-lg border px-2.5 text-sm"
                 onChange={(event) => {
                   updateField(
@@ -294,6 +306,11 @@ export function TransactionFormModal({ open, onClose, transaction }: Transaction
                     </option>
                   ))}
               </select>
+              {categoryError !== undefined && (
+                <p id={`${categoryFieldId}-error`} className="text-destructive text-xs">
+                  {categoryError}
+                </p>
+              )}
             </div>
             <div className="flex flex-col gap-1.5">
               <span className="text-sm leading-none font-medium">Need / Want</span>
@@ -313,6 +330,11 @@ export function TransactionFormModal({ open, onClose, transaction }: Transaction
                   </ToggleGroupItem>
                 ))}
               </ToggleGroup>
+              {needWantError !== undefined && (
+                <p id={`${needWantId}-error`} className="text-destructive text-xs">
+                  {needWantError}
+                </p>
+              )}
             </div>
             <div className="flex flex-col gap-1.5">
               <Label htmlFor={titleId}>Title</Label>
@@ -320,20 +342,34 @@ export function TransactionFormModal({ open, onClose, transaction }: Transaction
                 id={titleId}
                 type="text"
                 value={state.title}
+                aria-invalid={titleError !== undefined}
+                aria-describedby={titleError !== undefined ? `${titleId}-error` : undefined}
                 onChange={(event) => {
                   updateField("title", event.target.value);
                 }}
               />
+              {titleError !== undefined && (
+                <p id={`${titleId}-error`} className="text-destructive text-xs">
+                  {titleError}
+                </p>
+              )}
             </div>
             <div className="flex flex-col gap-1.5">
               <Label htmlFor={memoId}>Memo</Label>
               <Textarea
                 id={memoId}
                 value={state.memo}
+                aria-invalid={memoError !== undefined}
+                aria-describedby={memoError !== undefined ? `${memoId}-error` : undefined}
                 onChange={(event) => {
                   updateField("memo", event.target.value);
                 }}
               />
+              {memoError !== undefined && (
+                <p id={`${memoId}-error`} className="text-destructive text-xs">
+                  {memoError}
+                </p>
+              )}
             </div>
             <DialogFooter>
               {isEditMode && (

--- a/frontend/src/hooks/useApiError.test.tsx
+++ b/frontend/src/hooks/useApiError.test.tsx
@@ -1,0 +1,190 @@
+import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ToastProvider } from "../components/Toast";
+import { ApiException, NetworkException } from "../lib/api/errors";
+import { useApiError } from "./useApiError";
+
+const showError = vi.fn();
+
+vi.mock("./useToast", () => ({
+  useToast: () => ({
+    showError,
+    showSuccess: vi.fn(),
+  }),
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <ToastProvider>{children}</ToastProvider>;
+}
+
+function render() {
+  showError.mockReset();
+  return renderHook(() => useApiError(), { wrapper });
+}
+
+describe("useApiError", () => {
+  describe("422 with errors[]", () => {
+    it("populates fieldErrors keyed by camelCase field name", () => {
+      const { result } = render();
+      const error = new ApiException(422, {
+        type: "/errors/validation-error",
+        title: "Your request is not valid.",
+        status: 422,
+        detail: "One or more fields have validation errors.",
+        errors: [
+          { pointer: "#/amount", detail: "must be greater than 0" },
+          { pointer: "#/category_id", detail: "category not found" },
+        ],
+      });
+
+      act(() => {
+        result.current.handleError(error);
+      });
+
+      expect(result.current.fieldErrors).toEqual({
+        amount: "must be greater than 0",
+        categoryId: "category not found",
+      });
+    });
+
+    it("does not show a toast when field errors are present", () => {
+      const { result } = render();
+      const error = new ApiException(422, {
+        type: "/errors/validation-error",
+        title: "Your request is not valid.",
+        status: 422,
+        detail: "One or more fields have validation errors.",
+        errors: [{ pointer: "#/amount", detail: "must be greater than 0" }],
+      });
+
+      act(() => {
+        result.current.handleError(error);
+      });
+
+      expect(showError).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("422 without errors[]", () => {
+    it("falls back to a toast with the detail message", () => {
+      const { result } = render();
+      const error = new ApiException(422, {
+        type: "/errors/validation-error",
+        title: "Your request is not valid.",
+        status: 422,
+        detail: "amount must be positive",
+      });
+
+      act(() => {
+        result.current.handleError(error);
+      });
+
+      expect(showError).toHaveBeenCalledWith("amount must be positive");
+      expect(result.current.fieldErrors).toEqual({});
+    });
+  });
+
+  describe("non-422 ApiException", () => {
+    it("shows a toast with the detail message", () => {
+      const { result } = render();
+      const error = new ApiException(404, {
+        type: "about:blank",
+        title: "Not Found",
+        status: 404,
+        detail: "transaction not found",
+      });
+
+      act(() => {
+        result.current.handleError(error);
+      });
+
+      expect(showError).toHaveBeenCalledWith("transaction not found");
+      expect(result.current.fieldErrors).toEqual({});
+    });
+  });
+
+  describe("non-ApiException error", () => {
+    it("shows a generic toast for NetworkException", () => {
+      const { result } = render();
+
+      act(() => {
+        result.current.handleError(new NetworkException(new TypeError("fetch failed")));
+      });
+
+      expect(showError).toHaveBeenCalledWith("Network error. Please check your connection.");
+    });
+
+    it("shows a generic toast for unknown errors", () => {
+      const { result } = render();
+
+      act(() => {
+        result.current.handleError(new Error("boom"));
+      });
+
+      expect(showError).toHaveBeenCalledWith("Something went wrong. Please try again.");
+    });
+  });
+
+  describe("clearFieldError", () => {
+    it("removes only the specified field from fieldErrors", () => {
+      const { result } = render();
+      act(() => {
+        result.current.handleError(
+          new ApiException(422, {
+            type: "/errors/validation-error",
+            title: "Your request is not valid.",
+            status: 422,
+            detail: "One or more fields have validation errors.",
+            errors: [
+              { pointer: "#/amount", detail: "must be greater than 0" },
+              { pointer: "#/category_id", detail: "category not found" },
+            ],
+          }),
+        );
+      });
+
+      act(() => {
+        result.current.clearFieldError("amount");
+      });
+
+      expect(result.current.fieldErrors).toEqual({
+        categoryId: "category not found",
+      });
+    });
+
+    it("is a no-op when the field has no error", () => {
+      const { result } = render();
+
+      act(() => {
+        result.current.clearFieldError("amount");
+      });
+
+      expect(result.current.fieldErrors).toEqual({});
+    });
+  });
+
+  describe("clearAllFieldErrors", () => {
+    it("removes all field errors", () => {
+      const { result } = render();
+      act(() => {
+        result.current.handleError(
+          new ApiException(422, {
+            type: "/errors/validation-error",
+            title: "Your request is not valid.",
+            status: 422,
+            detail: "One or more fields have validation errors.",
+            errors: [{ pointer: "#/amount", detail: "must be greater than 0" }],
+          }),
+        );
+      });
+
+      act(() => {
+        result.current.clearAllFieldErrors();
+      });
+
+      expect(result.current.fieldErrors).toEqual({});
+    });
+  });
+});

--- a/frontend/src/hooks/useApiError.ts
+++ b/frontend/src/hooks/useApiError.ts
@@ -54,8 +54,7 @@ export function useApiError(): UseApiErrorReturn {
   const clearFieldError = useCallback((field: string) => {
     setFieldErrors((prev) => {
       if (!(field in prev)) return prev;
-      const { [field]: _removed, ...rest } = prev;
-      return rest;
+      return Object.fromEntries(Object.entries(prev).filter(([key]) => key !== field));
     });
   }, []);
 

--- a/frontend/src/hooks/useApiError.ts
+++ b/frontend/src/hooks/useApiError.ts
@@ -1,0 +1,67 @@
+/**
+ * Mutation のエラーをステータスコード別に処理するフック。
+ *
+ * - 422 + `errors[]` あり → フォームのインラインエラーとして state に保持
+ * - 422 で `errors[]` なし → `detail` をトースト
+ * - その他の `ApiException` → `detail` をトースト
+ * - `NetworkException` / 不明な例外 → 汎用メッセージをトースト
+ *
+ * 401 の JWT クリアは API クライアント層、ログイン画面リダイレクトは
+ * グローバルなエラーハンドラの責務として扱う。
+ *
+ * @see docs/03-design/common/error-handling.md
+ */
+
+import { useCallback, useState } from "react";
+
+import { ApiException, NetworkException } from "../lib/api/errors";
+import { extractFieldErrors } from "../lib/api/fieldErrors";
+import { useToast } from "./useToast";
+
+interface UseApiErrorReturn {
+  fieldErrors: Record<string, string>;
+  handleError: (error: unknown) => void;
+  clearFieldError: (field: string) => void;
+  clearAllFieldErrors: () => void;
+}
+
+export function useApiError(): UseApiErrorReturn {
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const { showError } = useToast();
+
+  const handleError = useCallback(
+    (error: unknown) => {
+      if (error instanceof ApiException) {
+        if (error.status === 422) {
+          const extracted = extractFieldErrors(error.apiError.errors);
+          if (Object.keys(extracted).length > 0) {
+            setFieldErrors(extracted);
+            return;
+          }
+        }
+        showError(error.apiError.detail);
+        return;
+      }
+      if (error instanceof NetworkException) {
+        showError("Network error. Please check your connection.");
+        return;
+      }
+      showError("Something went wrong. Please try again.");
+    },
+    [showError],
+  );
+
+  const clearFieldError = useCallback((field: string) => {
+    setFieldErrors((prev) => {
+      if (!(field in prev)) return prev;
+      const { [field]: _removed, ...rest } = prev;
+      return rest;
+    });
+  }, []);
+
+  const clearAllFieldErrors = useCallback(() => {
+    setFieldErrors({});
+  }, []);
+
+  return { fieldErrors, handleError, clearFieldError, clearAllFieldErrors };
+}

--- a/frontend/src/lib/api/fieldErrors.test.ts
+++ b/frontend/src/lib/api/fieldErrors.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import type { FieldError } from "../../types/api";
+import { extractFieldErrors, pointerToFieldName } from "./fieldErrors";
+
+describe("pointerToFieldName", () => {
+  it("returns the field name for a single-token pointer", () => {
+    expect(pointerToFieldName("#/amount")).toBe("amount");
+  });
+
+  it("converts snake_case pointer to camelCase field name", () => {
+    expect(pointerToFieldName("#/category_id")).toBe("categoryId");
+  });
+
+  it("converts multi-segment snake_case pointer to camelCase", () => {
+    expect(pointerToFieldName("#/need_want_type")).toBe("needWantType");
+  });
+
+  it("returns null when pointer does not start with the JSON pointer prefix", () => {
+    expect(pointerToFieldName("amount")).toBeNull();
+  });
+
+  it("returns null for an empty pointer", () => {
+    expect(pointerToFieldName("")).toBeNull();
+  });
+
+  it("returns null when pointer body is empty", () => {
+    expect(pointerToFieldName("#/")).toBeNull();
+  });
+});
+
+describe("extractFieldErrors", () => {
+  it("returns an empty record when errors is undefined", () => {
+    expect(extractFieldErrors(undefined)).toEqual({});
+  });
+
+  it("returns an empty record when errors is an empty array", () => {
+    expect(extractFieldErrors([])).toEqual({});
+  });
+
+  it("maps each pointer to its detail message keyed by camelCase field name", () => {
+    const errors: FieldError[] = [
+      { pointer: "#/amount", detail: "must be greater than 0" },
+      { pointer: "#/category_id", detail: "category not found" },
+    ];
+
+    expect(extractFieldErrors(errors)).toEqual({
+      amount: "must be greater than 0",
+      categoryId: "category not found",
+    });
+  });
+
+  it("keeps the first message when multiple errors target the same field", () => {
+    const errors: FieldError[] = [
+      { pointer: "#/amount", detail: "must be greater than 0" },
+      { pointer: "#/amount", detail: "must not be null" },
+    ];
+
+    expect(extractFieldErrors(errors)).toEqual({
+      amount: "must be greater than 0",
+    });
+  });
+
+  it("skips entries whose pointer cannot be resolved to a field name", () => {
+    const errors: FieldError[] = [
+      { pointer: "amount", detail: "ignored" },
+      { pointer: "#/amount", detail: "must be greater than 0" },
+    ];
+
+    expect(extractFieldErrors(errors)).toEqual({
+      amount: "must be greater than 0",
+    });
+  });
+});

--- a/frontend/src/lib/api/fieldErrors.ts
+++ b/frontend/src/lib/api/fieldErrors.ts
@@ -26,6 +26,7 @@ export function extractFieldErrors(errors: FieldError[] | undefined): Record<str
   for (const { pointer, detail } of errors) {
     const field = pointerToFieldName(pointer);
     if (field === null) continue;
+    // 同一フィールドに複数の制約違反がある場合は最初のメッセージのみ採用
     if (field in result) continue;
     result[field] = detail;
   }

--- a/frontend/src/lib/api/fieldErrors.ts
+++ b/frontend/src/lib/api/fieldErrors.ts
@@ -1,0 +1,33 @@
+/**
+ * RFC 9457 Problem Details の `errors[]` 配列に含まれる JSON Pointer を
+ * フォーム側の camelCase フィールド名に変換するユーティリティ。
+ *
+ * バックエンドはフィールド名を snake_case で表現するため
+ * (`#/category_id`)、フォーム側のキー (`categoryId`) と突合できるよう
+ * ここで変換する。
+ *
+ * @see docs/03-design/common/error-handling.md
+ */
+
+import type { FieldError } from "../../types/api";
+
+const POINTER_PREFIX = "#/";
+
+export function pointerToFieldName(pointer: string): string | null {
+  if (!pointer.startsWith(POINTER_PREFIX)) return null;
+  const body = pointer.slice(POINTER_PREFIX.length);
+  if (body.length === 0) return null;
+  return body.replace(/_([a-z])/g, (_, char: string) => char.toUpperCase());
+}
+
+export function extractFieldErrors(errors: FieldError[] | undefined): Record<string, string> {
+  const result: Record<string, string> = {};
+  if (errors === undefined) return result;
+  for (const { pointer, detail } of errors) {
+    const field = pointerToFieldName(pointer);
+    if (field === null) continue;
+    if (field in result) continue;
+    result[field] = detail;
+  }
+  return result;
+}


### PR DESCRIPTION
## 概要

API が返す 422 (Unprocessable Content) の `errors[]` を読み取り、対応するフォームフィールド下にメッセージを表示するインラインエラー表示を実装した。これにより `docs/03-design/common/error-handling.md` のフロー（422 → インライン / その他 → トースト）が満たされ、ユーザーがどのフィールドを直すべきか即座に把握できる。

## 変更内容

- 新規 `src/lib/api/fieldErrors.ts` — `pointer` (`#/snake_case`) を camelCase フィールド名に変換し、`Record<string, string>` 形式の fieldErrors マップを生成する純関数
- 新規 `src/hooks/useApiError.ts` — ステータスコード別エラーハンドリングフック
  - 422 + `errors[]` あり → `fieldErrors` ステートに格納（トーストは出さない）
  - 422 で `errors[]` なし → `detail` をトースト
  - その他の `ApiException` → `detail` をトースト
  - `NetworkException` / 不明な例外 → 汎用メッセージをトースト
- `TransactionFormModal.tsx` — `useApiError` を統合し、各フィールド (`date` / `amount` / `categoryId` / `needWantType` / `title` / `memo`) の下にメッセージと `aria-invalid` / `aria-describedby` を追加。入力修正時に該当フィールドのエラーを自動クリアする

## 関連 Issue

Closes #259

## スクリーンショット

- `frontend/screenshots/transaction-modal-422-inline-errors.png` — Add Transaction モーダルで Amount + Title に 422 を返した際のインライン表示
<img width="358" height="618" alt="transaction-modal-422-inline-errors" src="https://github.com/user-attachments/assets/2e0904b2-848e-4a6b-8e07-8c311f58a730" />


## テスト

- `npm run check` 全通過 (Vitest 317/317、Playwright 2/2、ESLint、tsc、Prettier、Vite ビルド)
- 追加した単体テスト
  - `fieldErrors.test.ts` — pointer 変換と `extractFieldErrors` の各ケース (11 件)
  - `useApiError.test.tsx` — 422+errors / 422 detail-only / 非 422 / NetworkException / 不明エラー / clearFieldError / clearAllFieldErrors (9 件)
  - `TransactionFormModal.test.tsx` — 422 で各フィールド下にエラー表示、トーストが出ないこと、入力修正で該当フィールドのみクリアされること (3 件追加)
- Playwright MCP で `window.fetch` を一時パッチし、`POST /api/v1/transactions` が `errors[]` 入り 422 を返す状態を再現。Amount フィールド下に "must be greater than 0"、Title フィールド下に "must be at most 200 characters" が赤字で表示され、両 input が `aria-invalid` の赤枠になり、トーストは表示されないことを確認。Amount を再入力するとそのフィールドのエラーのみが即座に消えることも目視確認した

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)