### PR TITLE
test(frontend): 支出新規登録の E2E テストを追加

### DIFF
--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -35,11 +35,8 @@ export async function seedAuthToken(page: Page, token = "mock-jwt-token"): Promi
 }
 
 /**
- * `GET /api/v1/transactions` のレスポンスを差し替える。
- *
- * デフォルトハンドラは常に空一覧を返すため、登録 → 一覧反映のような
- * 状態遷移を伴うシナリオではテストごとに `worker.use()` で挙動を上書きする必要がある。
- * `main.tsx` が VITE_ENABLE_MSW=true ビルドで window に公開する MSW ハンドルを使う。
+ * `GET /api/v1/transactions` のレスポンスを差し替える。デフォルトハンドラは常に
+ * 空一覧を返すため、登録 → 一覧反映のような状態遷移シナリオで使う。
  */
 export async function mockTransactionList(page: Page, items: TransactionResponse[]): Promise<void> {
   await page.evaluate((nextItems) => {
@@ -47,7 +44,9 @@ export async function mockTransactionList(page: Page, items: TransactionResponse
     const http = window.__mswHttp;
     const HttpResponse = window.__mswHttpResponse;
     if (!worker || !http || !HttpResponse) {
-      throw new Error("MSW worker is not initialized; ensure VITE_ENABLE_MSW=true build is used");
+      throw new Error(
+        "MSW E2E hooks are not exposed on window; run with VITE_ENABLE_MSW=true build (npm run dev:e2e / build:e2e)",
+      );
     }
     worker.use(http.get("/api/v1/transactions", () => HttpResponse.json({ items: nextItems })));
   }, items);

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -5,11 +5,21 @@
  * 個別ケースで応答を変えたいときは `worker.use(...)` を `page.evaluate` 経由で実行する。
  */
 
+import type { http as mswHttp, HttpResponse as MswHttpResponse } from "msw";
+import type { SetupWorker } from "msw/browser";
+
 import type { Page } from "@playwright/test";
+
+import type { components } from "../src/types/api-generated";
+
+type TransactionResponse = components["schemas"]["Transaction"];
 
 declare global {
   interface Window {
     __seedAuthToken?: string;
+    __mswWorker?: SetupWorker;
+    __mswHttp?: typeof mswHttp;
+    __mswHttpResponse?: typeof MswHttpResponse;
   }
 }
 
@@ -22,4 +32,23 @@ export async function seedAuthToken(page: Page, token = "mock-jwt-token"): Promi
   await page.addInitScript((value) => {
     window.__seedAuthToken = value;
   }, token);
+}
+
+/**
+ * `GET /api/v1/transactions` のレスポンスを差し替える。
+ *
+ * デフォルトハンドラは常に空一覧を返すため、登録 → 一覧反映のような
+ * 状態遷移を伴うシナリオではテストごとに `worker.use()` で挙動を上書きする必要がある。
+ * `main.tsx` が VITE_ENABLE_MSW=true ビルドで window に公開する MSW ハンドルを使う。
+ */
+export async function mockTransactionList(page: Page, items: TransactionResponse[]): Promise<void> {
+  await page.evaluate((nextItems) => {
+    const worker = window.__mswWorker;
+    const http = window.__mswHttp;
+    const HttpResponse = window.__mswHttpResponse;
+    if (!worker || !http || !HttpResponse) {
+      throw new Error("MSW worker is not initialized; ensure VITE_ENABLE_MSW=true build is used");
+    }
+    worker.use(http.get("/api/v1/transactions", () => HttpResponse.json({ items: nextItems })));
+  }, items);
 }

--- a/frontend/e2e/transactions.spec.ts
+++ b/frontend/e2e/transactions.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "@playwright/test";
+
+import { mockTransactionList, seedAuthToken } from "./fixtures";
+
+test("支出を新規登録するとモーダルが閉じて一覧に反映される", async ({ page }) => {
+  await seedAuthToken(page);
+  await page.goto("/transactions");
+
+  await expect(page.getByText(/No transactions yet/i)).toBeVisible();
+
+  await page.getByRole("button", { name: "Add transaction" }).click();
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByRole("heading", { name: "Add transaction" })).toBeVisible();
+
+  await dialog.getByLabel("Date").fill("2026-05-07");
+  await dialog.getByLabel("Amount").fill("1200");
+  await dialog.getByLabel("Category").selectOption({ label: "Food" });
+  await dialog.getByRole("radio", { name: "NEED" }).click();
+  await dialog.getByLabel("Title").fill("ランチ");
+  await dialog.getByLabel("Memo").fill("同僚と渋谷のイタリアンへ");
+
+  // 登録後の一覧 refetch で新規項目が返るよう、Save 押下前にハンドラを差し替える。
+  await mockTransactionList(page, [
+    {
+      id: 1,
+      date: "2026-05-07",
+      amount: "1200",
+      category_id: 1,
+      category_name: "Food",
+      need_want_type: "NEED",
+      title: "ランチ",
+      memo: "同僚と渋谷のイタリアンへ",
+      created_at: "2026-05-07T12:00:00Z",
+      updated_at: "2026-05-07T12:00:00Z",
+    },
+  ]);
+
+  await dialog.getByRole("button", { name: "Save" }).click();
+
+  await expect(dialog).toBeHidden();
+  await expect(page.getByText("ランチ")).toBeVisible();
+  await expect(page.getByText("NEED")).toBeVisible();
+
+  await page.screenshot({ path: "screenshots/transaction-create-success.png" });
+});

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -39,10 +39,9 @@ async function enableMocking(): Promise<void> {
   }
   const { worker, http, HttpResponse } = await import("./test/mocks/browser");
   await worker.start({ onUnhandledRequest: "bypass" });
-  // VITE_ENABLE_MSW が立つビルドでのみ E2E 向けのフックを公開する。
-  // __seedAuthToken: addInitScript で先置きしたトークンを React 起動前に適用する
-  // __setAuthToken / __mswWorker: テスト中に動的に切り替えるための窓口
-  // __mswHttp / __mswHttpResponse: page.evaluate からハンドラを構築するための窓口
+  // E2E から MSW を制御するために window へ橋渡しする（モジュール export では
+  // page.evaluate コンテキストから到達できないため）。本番ビルドではこのブロック
+  // ごと dead code として落ちる。
   if (typeof window.__seedAuthToken === "string") {
     setToken(window.__seedAuthToken);
   }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,7 @@
 import { GoogleOAuthProvider } from "@react-oauth/google";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import type { http as mswHttp, HttpResponse as MswHttpResponse } from "msw";
 import type { SetupWorker } from "msw/browser";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
@@ -16,6 +17,8 @@ declare global {
     __seedAuthToken?: string;
     __setAuthToken?: (token: string) => void;
     __mswWorker?: SetupWorker;
+    __mswHttp?: typeof mswHttp;
+    __mswHttpResponse?: typeof MswHttpResponse;
   }
 }
 
@@ -34,16 +37,19 @@ async function enableMocking(): Promise<void> {
   if (!ENABLE_MSW) {
     return;
   }
-  const { worker } = await import("./test/mocks/browser");
+  const { worker, http, HttpResponse } = await import("./test/mocks/browser");
   await worker.start({ onUnhandledRequest: "bypass" });
   // VITE_ENABLE_MSW が立つビルドでのみ E2E 向けのフックを公開する。
   // __seedAuthToken: addInitScript で先置きしたトークンを React 起動前に適用する
   // __setAuthToken / __mswWorker: テスト中に動的に切り替えるための窓口
+  // __mswHttp / __mswHttpResponse: page.evaluate からハンドラを構築するための窓口
   if (typeof window.__seedAuthToken === "string") {
     setToken(window.__seedAuthToken);
   }
   window.__setAuthToken = setToken;
   window.__mswWorker = worker;
+  window.__mswHttp = http;
+  window.__mswHttpResponse = HttpResponse;
 }
 
 void enableMocking().then(() => {

--- a/frontend/src/test/mocks/browser.ts
+++ b/frontend/src/test/mocks/browser.ts
@@ -1,10 +1,15 @@
 /**
  * ブラウザ用 MSW ワーカー。Vite ビルド時に `VITE_ENABLE_MSW=true` の場合のみ
  * `main.tsx` から起動し、Playwright の E2E と手元での開発でバックエンドをモックする。
+ *
+ * `http` / `HttpResponse` も合わせて re-export する。E2E テストから
+ * `window.__mswWorker.use(window.__mswHttp.get(...))` の形で動的にハンドラを差し替えるため。
  */
 
+import { http, HttpResponse } from "msw";
 import { setupWorker } from "msw/browser";
 
 import { handlers } from "./handlers";
 
+export { http, HttpResponse };
 export const worker = setupWorker(...handlers);

--- a/frontend/src/test/mocks/browser.ts
+++ b/frontend/src/test/mocks/browser.ts
@@ -1,9 +1,6 @@
 /**
  * ブラウザ用 MSW ワーカー。Vite ビルド時に `VITE_ENABLE_MSW=true` の場合のみ
  * `main.tsx` から起動し、Playwright の E2E と手元での開発でバックエンドをモックする。
- *
- * `http` / `HttpResponse` も合わせて re-export する。E2E テストから
- * `window.__mswWorker.use(window.__mswHttp.get(...))` の形で動的にハンドラを差し替えるため。
  */
 
 import { http, HttpResponse } from "msw";
@@ -11,5 +8,6 @@ import { setupWorker } from "msw/browser";
 
 import { handlers } from "./handlers";
 
+// E2E から worker.use() を組み立てるため http / HttpResponse も再公開する。
 export { http, HttpResponse };
 export const worker = setupWorker(...handlers);


### PR DESCRIPTION
## 概要

Issue #260（FE: E2E テスト不足分の整理と実装）のうち、優先度: 高 #1「支出の新規登録」E2E テストを実装する。あわせて、登録後の一覧反映を検証するために必要な MSW ハンドラ差し替えヘルパーを整備する。

## 変更内容

- `e2e/transactions.spec.ts` を新設し、`/transactions` 画面でモーダルを開く → フォーム入力 → 保存 → 一覧反映までのゴールデンパスを検証
- `e2e/fixtures.ts` に `mockTransactionList(page, items)` ヘルパーを追加。`worker.use()` 経由で GET `/api/v1/transactions` のレスポンスをテスト中に差し替えられる
- `src/test/mocks/browser.ts` で `http` / `HttpResponse` を re-export
- `src/main.tsx` で `window.__mswHttp` / `window.__mswHttpResponse` を公開（`VITE_ENABLE_MSW=true` のビルドのみ）

## スコープ外（後続 Issue で対応）

- #2〜#15 のテスト
- 既存 `app.spec.ts` の feature 別分割

## 関連 Issue

Refs #260

## テスト

- `npm run test:e2e` → 3 passed（既存 2 + 新規 1）
- `npm run check`（Prettier + ESLint + tsc + Vitest + build）すべてグリーン
- E2E 実行時に `screenshots/transaction-create-success.png` を取得し、「Transaction saved」トースト表示と一覧への反映を目視確認済み

`src/main.tsx` の変更は `window` への E2E 用フック追加のみで、UI には影響しない。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)