### PR TITLE
test(frontend): E2E ゴールデンパスの編集・削除・ナビ・分析・通貨切替を追加

### DIFF
--- a/frontend/e2e/analytics.spec.ts
+++ b/frontend/e2e/analytics.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  mockCategoryAnalytics,
+  mockNeedWantAnalytics,
+  refetchQueries,
+  seedAuthToken,
+} from "./fixtures";
+
+test("分析画面でカテゴリ内訳と Need/Want 比率が描画される", async ({ page }) => {
+  await seedAuthToken(page);
+  await page.goto("/analytics");
+
+  // 初期描画 (空状態) を待ってから MSW を差し替え、その後 refetch する。
+  await expect(page.getByRole("heading", { name: "Category Breakdown" })).toBeVisible();
+
+  await mockCategoryAnalytics(page, {
+    total_amount: "13000",
+    categories: [
+      {
+        category_id: 1,
+        category_name: "Food",
+        amount: "8000",
+        percentage: 61.5,
+        transaction_count: 12,
+      },
+      {
+        category_id: 2,
+        category_name: "Transport",
+        amount: "5000",
+        percentage: 38.5,
+        transaction_count: 4,
+      },
+    ],
+  });
+  await mockNeedWantAnalytics(page, {
+    total_amount: "13000",
+    breakdown: [
+      { type: "NEED", amount: "8000", percentage: 61.5, transaction_count: 12 },
+      { type: "WANT", amount: "4000", percentage: 30.8, transaction_count: 3 },
+      { type: "UNSET", amount: "1000", percentage: 7.7, transaction_count: 1 },
+    ],
+  });
+  await refetchQueries(page);
+
+  const categorySection = page.getByRole("region", { name: "Category Breakdown" });
+  await expect(categorySection).toBeVisible();
+  await expect(categorySection.getByText("Food")).toBeVisible();
+  await expect(categorySection.getByText("Transport")).toBeVisible();
+  await expect(categorySection.getByText("61.5%")).toBeVisible();
+
+  const needWantSection = page.getByRole("region", { name: "Need / Want Ratio" });
+  await expect(needWantSection).toBeVisible();
+  await expect(needWantSection.getByLabel("NEED")).toBeVisible();
+  await expect(needWantSection.getByLabel("WANT")).toBeVisible();
+  await expect(needWantSection.getByLabel("UNSET")).toBeVisible();
+  await expect(needWantSection.getByRole("note")).toContainText("1 transaction unset");
+
+  // recharts の Pie は ResizeObserver で 2 段階に描画され、さらに各 sector が
+  // アニメーションで描画されるため、全 sector が出揃うまで待ってから撮影する。
+  await expect(categorySection.locator(".recharts-pie-sector")).toHaveCount(2);
+  await page.waitForTimeout(1600);
+
+  // recharts を含むため fullPage は避け、各セクションを要素単位で撮影する。
+  await categorySection.screenshot({ path: "screenshots/analytics-category.png" });
+  await needWantSection.screenshot({ path: "screenshots/analytics-need-want.png" });
+});

--- a/frontend/e2e/analytics.spec.ts
+++ b/frontend/e2e/analytics.spec.ts
@@ -11,7 +11,8 @@ test("分析画面でカテゴリ内訳と Need/Want 比率が描画される", 
   await seedAuthToken(page);
   await page.goto("/analytics");
 
-  // 初期描画 (空状態) を待ってから MSW を差し替え、その後 refetch する。
+  // enableMocking が非同期で window フックを公開するため、初期描画を待ってから
+  // worker.use() を呼ばないと差し替えが間に合わない。
   await expect(page.getByRole("heading", { name: "Category Breakdown" })).toBeVisible();
 
   await mockCategoryAnalytics(page, {

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -6,7 +6,7 @@
  */
 
 import type { QueryClient } from "@tanstack/react-query";
-import type { http as mswHttp, HttpResponse as MswHttpResponse } from "msw";
+import type { JsonBodyType, http as mswHttp, HttpResponse as MswHttpResponse } from "msw";
 import type { SetupWorker } from "msw/browser";
 
 import type { Page } from "@playwright/test";
@@ -39,11 +39,10 @@ export async function seedAuthToken(page: Page, token = "mock-jwt-token"): Promi
 }
 
 /**
- * MSW のフック（`__mswWorker` / `__mswHttp` / `__mswHttpResponse`）が
- * `window` に公開されるまで待つ。`enableMocking` は非同期なので、
- * `goto` 直後に `worker.use()` を呼ぶ前に必ず通す。
+ * `enableMocking` が非同期で window フックを公開するため、`goto` 直後に
+ * `worker.use()` / `queryClient.invalidateQueries()` を呼ぶ前に必ず通す。
  */
-async function waitForMswReady(page: Page): Promise<void> {
+async function waitForE2EHooks(page: Page): Promise<void> {
   await page.waitForFunction(
     () =>
       typeof window.__mswWorker !== "undefined" &&
@@ -53,82 +52,54 @@ async function waitForMswReady(page: Page): Promise<void> {
   );
 }
 
+const HOOKS_NOT_EXPOSED =
+  "E2E hooks are not exposed on window; run with VITE_ENABLE_MSW=true build (npm run dev:e2e / build:e2e)";
+
 /**
- * MSW のレスポンス差し替え後に、TanStack Query のキャッシュを破棄して
- * 全クエリを再フェッチさせる。`worker.use()` だけでは既にキャッシュ済みの
- * 結果がそのまま使われるため、表示反映には refetch が必要。
+ * `worker.use()` だけでは既にキャッシュ済みのレスポンスがそのまま使われるため、
+ * モック差し替え後に表示反映させたいときに呼ぶ。
  */
 export async function refetchQueries(page: Page): Promise<void> {
-  await waitForMswReady(page);
-  await page.evaluate(async () => {
+  await waitForE2EHooks(page);
+  await page.evaluate(async (errorMessage) => {
     const queryClient = window.__queryClient;
     if (!queryClient) {
-      throw new Error(
-        "QueryClient is not exposed on window; run with VITE_ENABLE_MSW=true build (npm run dev:e2e / build:e2e)",
-      );
+      throw new Error(errorMessage);
     }
     await queryClient.invalidateQueries();
-  });
+  }, HOOKS_NOT_EXPOSED);
 }
 
-/**
- * `GET /api/v1/transactions` のレスポンスを差し替える。デフォルトハンドラは常に
- * 空一覧を返すため、登録 → 一覧反映のような状態遷移シナリオで使う。
- */
-export async function mockTransactionList(page: Page, items: TransactionResponse[]): Promise<void> {
-  await waitForMswReady(page);
-  await page.evaluate((nextItems) => {
-    const worker = window.__mswWorker;
-    const http = window.__mswHttp;
-    const HttpResponse = window.__mswHttpResponse;
-    if (!worker || !http || !HttpResponse) {
-      throw new Error(
-        "MSW E2E hooks are not exposed on window; run with VITE_ENABLE_MSW=true build (npm run dev:e2e / build:e2e)",
-      );
-    }
-    worker.use(http.get("/api/v1/transactions", () => HttpResponse.json({ items: nextItems })));
-  }, items);
+async function mockGet(page: Page, path: string, payload: JsonBodyType): Promise<void> {
+  await waitForE2EHooks(page);
+  await page.evaluate(
+    ({ path, payload, errorMessage }) => {
+      const worker = window.__mswWorker;
+      const http = window.__mswHttp;
+      const HttpResponse = window.__mswHttpResponse;
+      if (!worker || !http || !HttpResponse) {
+        throw new Error(errorMessage);
+      }
+      worker.use(http.get(path, () => HttpResponse.json(payload)));
+    },
+    { path, payload, errorMessage: HOOKS_NOT_EXPOSED },
+  );
 }
 
-/**
- * `GET /api/v1/analytics/category` のレスポンスを差し替える。デフォルトハンドラは
- * 空応答を返すため、チャート描画やリスト表示の検証で使う。
- */
-export async function mockCategoryAnalytics(
+export function mockTransactionList(page: Page, items: TransactionResponse[]): Promise<void> {
+  return mockGet(page, "/api/v1/transactions", { items });
+}
+
+export function mockCategoryAnalytics(
   page: Page,
   payload: CategoryAnalyticsResponse,
 ): Promise<void> {
-  await waitForMswReady(page);
-  await page.evaluate((nextPayload) => {
-    const worker = window.__mswWorker;
-    const http = window.__mswHttp;
-    const HttpResponse = window.__mswHttpResponse;
-    if (!worker || !http || !HttpResponse) {
-      throw new Error(
-        "MSW E2E hooks are not exposed on window; run with VITE_ENABLE_MSW=true build (npm run dev:e2e / build:e2e)",
-      );
-    }
-    worker.use(http.get("/api/v1/analytics/category", () => HttpResponse.json(nextPayload)));
-  }, payload);
+  return mockGet(page, "/api/v1/analytics/category", payload);
 }
 
-/**
- * `GET /api/v1/analytics/need-want` のレスポンスを差し替える。
- */
-export async function mockNeedWantAnalytics(
+export function mockNeedWantAnalytics(
   page: Page,
   payload: NeedWantAnalyticsResponse,
 ): Promise<void> {
-  await waitForMswReady(page);
-  await page.evaluate((nextPayload) => {
-    const worker = window.__mswWorker;
-    const http = window.__mswHttp;
-    const HttpResponse = window.__mswHttpResponse;
-    if (!worker || !http || !HttpResponse) {
-      throw new Error(
-        "MSW E2E hooks are not exposed on window; run with VITE_ENABLE_MSW=true build (npm run dev:e2e / build:e2e)",
-      );
-    }
-    worker.use(http.get("/api/v1/analytics/need-want", () => HttpResponse.json(nextPayload)));
-  }, payload);
+  return mockGet(page, "/api/v1/analytics/need-want", payload);
 }

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -5,6 +5,7 @@
  * 個別ケースで応答を変えたいときは `worker.use(...)` を `page.evaluate` 経由で実行する。
  */
 
+import type { QueryClient } from "@tanstack/react-query";
 import type { http as mswHttp, HttpResponse as MswHttpResponse } from "msw";
 import type { SetupWorker } from "msw/browser";
 
@@ -13,6 +14,8 @@ import type { Page } from "@playwright/test";
 import type { components } from "../src/types/api-generated";
 
 type TransactionResponse = components["schemas"]["Transaction"];
+type CategoryAnalyticsResponse = components["schemas"]["CategoryAnalytics"];
+type NeedWantAnalyticsResponse = components["schemas"]["NeedWantAnalytics"];
 
 declare global {
   interface Window {
@@ -20,6 +23,7 @@ declare global {
     __mswWorker?: SetupWorker;
     __mswHttp?: typeof mswHttp;
     __mswHttpResponse?: typeof MswHttpResponse;
+    __queryClient?: QueryClient;
   }
 }
 
@@ -35,10 +39,44 @@ export async function seedAuthToken(page: Page, token = "mock-jwt-token"): Promi
 }
 
 /**
+ * MSW のフック（`__mswWorker` / `__mswHttp` / `__mswHttpResponse`）が
+ * `window` に公開されるまで待つ。`enableMocking` は非同期なので、
+ * `goto` 直後に `worker.use()` を呼ぶ前に必ず通す。
+ */
+async function waitForMswReady(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () =>
+      typeof window.__mswWorker !== "undefined" &&
+      typeof window.__mswHttp !== "undefined" &&
+      typeof window.__mswHttpResponse !== "undefined" &&
+      typeof window.__queryClient !== "undefined",
+  );
+}
+
+/**
+ * MSW のレスポンス差し替え後に、TanStack Query のキャッシュを破棄して
+ * 全クエリを再フェッチさせる。`worker.use()` だけでは既にキャッシュ済みの
+ * 結果がそのまま使われるため、表示反映には refetch が必要。
+ */
+export async function refetchQueries(page: Page): Promise<void> {
+  await waitForMswReady(page);
+  await page.evaluate(async () => {
+    const queryClient = window.__queryClient;
+    if (!queryClient) {
+      throw new Error(
+        "QueryClient is not exposed on window; run with VITE_ENABLE_MSW=true build (npm run dev:e2e / build:e2e)",
+      );
+    }
+    await queryClient.invalidateQueries();
+  });
+}
+
+/**
  * `GET /api/v1/transactions` のレスポンスを差し替える。デフォルトハンドラは常に
  * 空一覧を返すため、登録 → 一覧反映のような状態遷移シナリオで使う。
  */
 export async function mockTransactionList(page: Page, items: TransactionResponse[]): Promise<void> {
+  await waitForMswReady(page);
   await page.evaluate((nextItems) => {
     const worker = window.__mswWorker;
     const http = window.__mswHttp;
@@ -50,4 +88,47 @@ export async function mockTransactionList(page: Page, items: TransactionResponse
     }
     worker.use(http.get("/api/v1/transactions", () => HttpResponse.json({ items: nextItems })));
   }, items);
+}
+
+/**
+ * `GET /api/v1/analytics/category` のレスポンスを差し替える。デフォルトハンドラは
+ * 空応答を返すため、チャート描画やリスト表示の検証で使う。
+ */
+export async function mockCategoryAnalytics(
+  page: Page,
+  payload: CategoryAnalyticsResponse,
+): Promise<void> {
+  await waitForMswReady(page);
+  await page.evaluate((nextPayload) => {
+    const worker = window.__mswWorker;
+    const http = window.__mswHttp;
+    const HttpResponse = window.__mswHttpResponse;
+    if (!worker || !http || !HttpResponse) {
+      throw new Error(
+        "MSW E2E hooks are not exposed on window; run with VITE_ENABLE_MSW=true build (npm run dev:e2e / build:e2e)",
+      );
+    }
+    worker.use(http.get("/api/v1/analytics/category", () => HttpResponse.json(nextPayload)));
+  }, payload);
+}
+
+/**
+ * `GET /api/v1/analytics/need-want` のレスポンスを差し替える。
+ */
+export async function mockNeedWantAnalytics(
+  page: Page,
+  payload: NeedWantAnalyticsResponse,
+): Promise<void> {
+  await waitForMswReady(page);
+  await page.evaluate((nextPayload) => {
+    const worker = window.__mswWorker;
+    const http = window.__mswHttp;
+    const HttpResponse = window.__mswHttpResponse;
+    if (!worker || !http || !HttpResponse) {
+      throw new Error(
+        "MSW E2E hooks are not exposed on window; run with VITE_ENABLE_MSW=true build (npm run dev:e2e / build:e2e)",
+      );
+    }
+    worker.use(http.get("/api/v1/analytics/need-want", () => HttpResponse.json(nextPayload)));
+  }, payload);
 }

--- a/frontend/e2e/navigation.spec.ts
+++ b/frontend/e2e/navigation.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "@playwright/test";
+
+import { seedAuthToken } from "./fixtures";
+
+test("ボトムナビで Transactions ↔ Analytics ↔ Settings を行き来できる", async ({ page }) => {
+  await seedAuthToken(page);
+  await page.goto("/transactions");
+
+  await expect(page.getByRole("button", { name: /add transaction/i })).toBeVisible();
+
+  const nav = page.getByRole("navigation");
+  await nav.getByRole("link", { name: "Analytics" }).click();
+  await expect(page).toHaveURL(/\/analytics$/);
+  await expect(page.getByRole("heading", { name: "Category Breakdown" })).toBeVisible();
+
+  await nav.getByRole("link", { name: "Settings" }).click();
+  await expect(page).toHaveURL(/\/settings$/);
+  await expect(page.getByRole("heading", { name: "Settings", level: 1 })).toBeVisible();
+
+  await nav.getByRole("link", { name: "Transactions" }).click();
+  await expect(page).toHaveURL(/\/transactions$/);
+  await expect(page.getByRole("button", { name: /add transaction/i })).toBeVisible();
+
+  await page.screenshot({ path: "screenshots/bottom-nav-transactions.png" });
+});

--- a/frontend/e2e/settings.spec.ts
+++ b/frontend/e2e/settings.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "@playwright/test";
+
+import { mockTransactionList, refetchQueries, seedAuthToken } from "./fixtures";
+
+test("設定画面で通貨を切り替えると一覧の通貨表記が更新される", async ({ page }) => {
+  await seedAuthToken(page);
+
+  // useCurrency は localStorage に保存するため、テスト独立性のため明示的にクリアする。
+  await page.addInitScript(() => {
+    localStorage.removeItem("expense-tracker:currency");
+  });
+
+  await page.goto("/transactions");
+  await expect(page.getByText(/No transactions yet/i)).toBeVisible();
+
+  await mockTransactionList(page, [
+    {
+      id: 1,
+      date: "2026-05-07",
+      amount: "1234",
+      category_id: 1,
+      category_name: "Food",
+      need_want_type: "NEED",
+      title: "コーヒー",
+      created_at: "2026-05-07T08:00:00Z",
+      updated_at: "2026-05-07T08:00:00Z",
+    },
+  ]);
+  await refetchQueries(page);
+
+  // 既定では navigator.language（en-US）由来の USD 表示になる。
+  await expect(page.getByText("$1,234.00")).toBeVisible();
+
+  await page.getByRole("navigation").getByRole("link", { name: "Settings" }).click();
+  await expect(page).toHaveURL(/\/settings$/);
+
+  await page.getByRole("button", { name: /^Currency/ }).click();
+
+  const picker = page.getByRole("dialog", { name: "Select currency" });
+  await expect(picker).toBeVisible();
+  await picker.getByRole("radio", { name: /^JPY/ }).click();
+
+  const confirm = page.getByRole("alertdialog");
+  await expect(confirm).toBeVisible();
+  await expect(confirm.getByRole("heading", { name: "Change display currency?" })).toBeVisible();
+  await confirm.getByRole("button", { name: "Change" }).click();
+
+  await expect(picker).toBeHidden();
+  await page.screenshot({ path: "screenshots/settings-currency-jpy.png" });
+
+  await page.getByRole("navigation").getByRole("link", { name: "Transactions" }).click();
+  await expect(page).toHaveURL(/\/transactions$/);
+
+  // JPY は端数なしで表示される。
+  await expect(page.getByText("¥1,234")).toBeVisible();
+  await expect(page.getByText("$1,234.00")).toBeHidden();
+
+  await page.screenshot({ path: "screenshots/transactions-currency-jpy.png" });
+});

--- a/frontend/e2e/transactions.spec.ts
+++ b/frontend/e2e/transactions.spec.ts
@@ -99,3 +99,47 @@ test("既存の支出をクリックして編集すると一覧の表示が更�
 
   await page.screenshot({ path: "screenshots/transaction-edit-success.png" });
 });
+
+test("既存の支出を編集モーダルから削除すると一覧が空に戻る", async ({ page }) => {
+  await seedAuthToken(page);
+  await page.goto("/transactions");
+  await expect(page.getByText(/No transactions yet/i)).toBeVisible();
+
+  await mockTransactionList(page, [
+    {
+      id: 99,
+      date: "2026-05-07",
+      amount: "1500",
+      category_id: 6,
+      category_name: "Entertainment",
+      need_want_type: "WANT",
+      title: "映画",
+      created_at: "2026-05-07T19:00:00Z",
+      updated_at: "2026-05-07T19:00:00Z",
+    },
+  ]);
+  await refetchQueries(page);
+
+  await page.getByRole("button", { name: /映画/ }).click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(dialog.getByRole("heading", { name: "Edit Transaction" })).toBeVisible();
+
+  await dialog.getByRole("button", { name: "Delete" }).click();
+
+  const confirm = page.getByRole("alertdialog");
+  await expect(confirm).toBeVisible();
+  await expect(confirm.getByRole("heading", { name: "Delete this transaction?" })).toBeVisible();
+
+  // 削除確定後の一覧 refetch で空が返るよう、Confirm 押下前にハンドラを差し替える。
+  await mockTransactionList(page, []);
+
+  await confirm.getByRole("button", { name: "Delete" }).click();
+
+  await expect(dialog).toBeHidden();
+  await expect(confirm).toBeHidden();
+  await expect(page.getByText(/No transactions yet/i)).toBeVisible();
+  await expect(page.getByText("映画")).toBeHidden();
+
+  await page.screenshot({ path: "screenshots/transaction-delete-success.png" });
+});

--- a/frontend/e2e/transactions.spec.ts
+++ b/frontend/e2e/transactions.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-import { mockTransactionList, seedAuthToken } from "./fixtures";
+import { mockTransactionList, refetchQueries, seedAuthToken } from "./fixtures";
 
 test("支出を新規登録するとモーダルが閉じて一覧に反映される", async ({ page }) => {
   await seedAuthToken(page);
@@ -43,4 +43,59 @@ test("支出を新規登録するとモーダルが閉じて一覧に反映さ�
   await expect(page.getByText("NEED")).toBeVisible();
 
   await page.screenshot({ path: "screenshots/transaction-create-success.png" });
+});
+
+test("既存の支出をクリックして編集すると一覧の表示が更新される", async ({ page }) => {
+  await seedAuthToken(page);
+  await page.goto("/transactions");
+  await expect(page.getByText(/No transactions yet/i)).toBeVisible();
+
+  await mockTransactionList(page, [
+    {
+      id: 42,
+      date: "2026-05-07",
+      amount: "1200",
+      category_id: 1,
+      category_name: "Food",
+      need_want_type: "NEED",
+      title: "ランチ",
+      memo: "同僚と渋谷のイタリアンへ",
+      created_at: "2026-05-07T12:00:00Z",
+      updated_at: "2026-05-07T12:00:00Z",
+    },
+  ]);
+  await refetchQueries(page);
+
+  await page.getByRole("button", { name: /ランチ/ }).click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByRole("heading", { name: "Edit Transaction" })).toBeVisible();
+  await expect(dialog.getByLabel("Title")).toHaveValue("ランチ");
+
+  await dialog.getByLabel("Title").fill("ディナー");
+
+  // 更新後の一覧 refetch で変更後のタイトルが返るよう、Save 押下前にハンドラを差し替える。
+  await mockTransactionList(page, [
+    {
+      id: 42,
+      date: "2026-05-07",
+      amount: "1200",
+      category_id: 1,
+      category_name: "Food",
+      need_want_type: "NEED",
+      title: "ディナー",
+      memo: "同僚と渋谷のイタリアンへ",
+      created_at: "2026-05-07T12:00:00Z",
+      updated_at: "2026-05-07T13:00:00Z",
+    },
+  ]);
+
+  await dialog.getByRole("button", { name: "Save" }).click();
+
+  await expect(dialog).toBeHidden();
+  await expect(page.getByText("ディナー")).toBeVisible();
+  await expect(page.getByText("ランチ")).toBeHidden();
+
+  await page.screenshot({ path: "screenshots/transaction-edit-success.png" });
 });

--- a/frontend/e2e/transactions.spec.ts
+++ b/frontend/e2e/transactions.spec.ts
@@ -46,24 +46,24 @@ test("支出を新規登録するとモーダルが閉じて一覧に反映さ�
 });
 
 test("既存の支出をクリックして編集すると一覧の表示が更新される", async ({ page }) => {
+  const lunch = {
+    id: 42,
+    date: "2026-05-07",
+    amount: "1200",
+    category_id: 1,
+    category_name: "Food",
+    need_want_type: "NEED" as const,
+    title: "ランチ",
+    memo: "同僚と渋谷のイタリアンへ",
+    created_at: "2026-05-07T12:00:00Z",
+    updated_at: "2026-05-07T12:00:00Z",
+  };
+
   await seedAuthToken(page);
   await page.goto("/transactions");
   await expect(page.getByText(/No transactions yet/i)).toBeVisible();
 
-  await mockTransactionList(page, [
-    {
-      id: 42,
-      date: "2026-05-07",
-      amount: "1200",
-      category_id: 1,
-      category_name: "Food",
-      need_want_type: "NEED",
-      title: "ランチ",
-      memo: "同僚と渋谷のイタリアンへ",
-      created_at: "2026-05-07T12:00:00Z",
-      updated_at: "2026-05-07T12:00:00Z",
-    },
-  ]);
+  await mockTransactionList(page, [lunch]);
   await refetchQueries(page);
 
   await page.getByRole("button", { name: /ランチ/ }).click();
@@ -77,18 +77,7 @@ test("既存の支出をクリックして編集すると一覧の表示が更�
 
   // 更新後の一覧 refetch で変更後のタイトルが返るよう、Save 押下前にハンドラを差し替える。
   await mockTransactionList(page, [
-    {
-      id: 42,
-      date: "2026-05-07",
-      amount: "1200",
-      category_id: 1,
-      category_name: "Food",
-      need_want_type: "NEED",
-      title: "ディナー",
-      memo: "同僚と渋谷のイタリアンへ",
-      created_at: "2026-05-07T12:00:00Z",
-      updated_at: "2026-05-07T13:00:00Z",
-    },
+    { ...lunch, title: "ディナー", updated_at: "2026-05-07T13:00:00Z" },
   ]);
 
   await dialog.getByRole("button", { name: "Save" }).click();

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,5 +1,5 @@
 import { GoogleOAuthProvider } from "@react-oauth/google";
-import { QueryClientProvider } from "@tanstack/react-query";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import type { http as mswHttp, HttpResponse as MswHttpResponse } from "msw";
 import type { SetupWorker } from "msw/browser";
@@ -19,6 +19,7 @@ declare global {
     __mswWorker?: SetupWorker;
     __mswHttp?: typeof mswHttp;
     __mswHttpResponse?: typeof MswHttpResponse;
+    __queryClient?: QueryClient;
   }
 }
 
@@ -49,6 +50,8 @@ async function enableMocking(): Promise<void> {
   window.__mswWorker = worker;
   window.__mswHttp = http;
   window.__mswHttpResponse = HttpResponse;
+  // E2E から `worker.use()` 後に手動で再フェッチを起こすために QueryClient を公開する。
+  window.__queryClient = queryClient;
 }
 
 void enableMocking().then(() => {


### PR DESCRIPTION
## 概要

Issue #260 のゴールデンパス #2〜#6 を E2E テストとして実装する。`frontend/e2e/` のカバレッジが「画面が描画される」だけだった状態から、CRUD・画面遷移・横断シナリオまで広げる。

## 変更内容

### 追加した E2E テスト

- **`#2` 支出の編集** (`transactions.spec.ts`): 既存項目クリック → 編集モーダル → タイトル変更 → 保存 → 一覧反映
- **`#3` 支出の削除** (`transactions.spec.ts`): 編集モーダル → Delete → DeleteConfirmDialog → 削除 → 空状態
- **`#4` ボトムナビ遷移** (`navigation.spec.ts` 新規): Transactions ↔ Analytics ↔ Settings の往復で URL と各画面の代表要素が描画されることを検証
- **`#5 `分析画面** (`analytics.spec.ts` 新規): カテゴリ内訳の Pie + リストと NEED/WANT/UNSET 比率が描画されることを検証。recharts のアニメーション完了を待ってから要素単位撮影することで、fullPage 撮影時にチャートが空白になる事故を回避
- **`#6` 設定画面・通貨切替** (`settings.spec.ts` 新規): USD → JPY に切り替えると一覧の金額表示が \`¥1,234\` 表記になることを検証

### インフラ補強

- \`fixtures.ts\`: \`mockGet\` ヘルパーを核として \`mockTransactionList\` / \`mockCategoryAnalytics\` / \`mockNeedWantAnalytics\` を整備（既存実装の重複を集約しつつ analytics をカバー）
- \`fixtures.ts\`: \`refetchQueries\` を追加。\`worker.use()\` だけでは既にキャッシュ済みのクエリ結果がそのまま使われるため、表示反映に明示的な invalidate が必要
- \`main.tsx\`: \`VITE_ENABLE_MSW=true\` ビルドでのみ \`window.__queryClient\` を公開（本番ビルドではコードごと dead code 落ちる）

### スコープ外

Issue #260 の #7 以降（フィルタ・422・401・未認証保護ルート・ログイン成功フロー）と \`app.spec.ts\` の \`auth.spec.ts\` への分割は別 PR に切り出す。

## 関連 Issue

Refs #260

## スクリーンショット

新規/拡張テストが生成するスクショ（PR 本文に手動添付してください）:

- frontend/screenshots/transaction-edit-success.png
<img width="1280" height="720" alt="transaction-edit-success" src="https://github.com/user-attachments/assets/c094c73d-ea70-4242-9cdc-c2ed8f4a87de" />

- frontend/screenshots/transaction-delete-success.png
<img width="1280" height="720" alt="transaction-delete-success" src="https://github.com/user-attachments/assets/4aa54a39-3936-46a6-bf20-673f81429d03" />

- frontend/screenshots/bottom-nav-transactions.png
<img width="1280" height="720" alt="bottom-nav-transactions" src="https://github.com/user-attachments/assets/18d6228a-0e8e-42d3-9576-7ce56b729b94" />

- frontend/screenshots/analytics-category.png
<img width="1280" height="413" alt="analytics-category" src="https://github.com/user-attachments/assets/42fe7f70-bd75-485d-b36e-8996cff6170f" />

- frontend/screenshots/analytics-need-want.png
<img width="1280" height="196" alt="analytics-need-want" src="https://github.com/user-attachments/assets/a1e6bc1e-9fc6-456a-b69a-5a33b45631fd" />

- frontend/screenshots/settings-currency-jpy.png
<img width="1280" height="720" alt="settings-currency-jpy" src="https://github.com/user-attachments/assets/9bc1d1d8-1170-4f70-a305-11d8d3a040e5" />

- frontend/screenshots/transactions-currency-jpy.png
<img width="1280" height="720" alt="transactions-currency-jpy" src="https://github.com/user-attachments/assets/507a2a8e-f548-4065-b417-820efa66638e" />

## テスト

- \`npm run test:e2e\`: 新規 5 ケース + 既存 3 ケース の計 8 ケース pass
- \`npm run check\`: Prettier + ESLint + tsc + Vitest（317 件）+ Playwright + build すべて pass

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)