### PR TITLE
test(frontend): E2E 重要エッジケース 5 件と 401 グローバルリダイレクトを追加

### DIFF
--- a/frontend/e2e/auth.spec.ts
+++ b/frontend/e2e/auth.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "@playwright/test";
 
+import { mockApiError, refetchQueries, seedAuthToken } from "./fixtures";
+
 test("未認証で /analytics に直接アクセスするとログインページにリダイレクトされる", async ({
   page,
 }) => {
@@ -13,6 +15,25 @@ test("未認証で /settings に直接アクセスするとログインページ
   page,
 }) => {
   await page.goto("/settings");
+
+  await expect(page).toHaveURL(/\/login/);
+  await expect(page.getByRole("heading", { name: "Expense Tracker" })).toBeVisible();
+});
+
+test("認証済み状態で API が 401 を返すとログインページにリダイレクトされる", async ({ page }) => {
+  await seedAuthToken(page);
+  await page.goto("/transactions");
+  await expect(page.getByText(/No transactions yet/i)).toBeVisible();
+
+  // BE がトークン期限切れで 401 を返したケースを模倣する。
+  // API クライアントがトークンを破棄し、グローバルハンドラが /login に飛ばす。
+  await mockApiError(page, "get", "/api/v1/transactions", 401, {
+    type: "/errors/unauthorized",
+    title: "Unauthorized",
+    status: 401,
+    detail: "Token expired",
+  });
+  await refetchQueries(page);
 
   await expect(page).toHaveURL(/\/login/);
   await expect(page.getByRole("heading", { name: "Expense Tracker" })).toBeVisible();

--- a/frontend/e2e/auth.spec.ts
+++ b/frontend/e2e/auth.spec.ts
@@ -39,6 +39,28 @@ test("認証済み状態で API が 401 を返すとログインページにリ�
   await expect(page.getByRole("heading", { name: "Expense Tracker" })).toBeVisible();
 });
 
+test("401 リダイレクト時に React Query のキャッシュが破棄される", async ({ page }) => {
+  // 別アカウントで再ログインしたときに前ユーザーのキャッシュが残らないことの回帰テスト。
+  await seedAuthToken(page);
+  await page.goto("/transactions");
+  await expect(page.getByText(/No transactions yet/i)).toBeVisible();
+
+  await mockApiError(page, "get", "/api/v1/transactions", 401, {
+    type: "/errors/unauthorized",
+    title: "Unauthorized",
+    status: 401,
+    detail: "Token expired",
+  });
+  await refetchQueries(page);
+
+  await expect(page).toHaveURL(/\/login/);
+
+  const queryCount = await page.evaluate(
+    () => window.__queryClient?.getQueryCache().getAll().length ?? -1,
+  );
+  expect(queryCount).toBe(0);
+});
+
 test("Sign in with Google ボタンを押すとログインに成功して /transactions に遷移する", async ({
   page,
 }) => {

--- a/frontend/e2e/auth.spec.ts
+++ b/frontend/e2e/auth.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "@playwright/test";
+
+test("未認証で /analytics に直接アクセスするとログインページにリダイレクトされる", async ({
+  page,
+}) => {
+  await page.goto("/analytics");
+
+  await expect(page).toHaveURL(/\/login/);
+  await expect(page.getByRole("heading", { name: "Expense Tracker" })).toBeVisible();
+});
+
+test("未認証で /settings に直接アクセスするとログインページにリダイレクトされる", async ({
+  page,
+}) => {
+  await page.goto("/settings");
+
+  await expect(page).toHaveURL(/\/login/);
+  await expect(page.getByRole("heading", { name: "Expense Tracker" })).toBeVisible();
+});

--- a/frontend/e2e/auth.spec.ts
+++ b/frontend/e2e/auth.spec.ts
@@ -17,3 +17,18 @@ test("未認証で /settings に直接アクセスするとログインページ
   await expect(page).toHaveURL(/\/login/);
   await expect(page.getByRole("heading", { name: "Expense Tracker" })).toBeVisible();
 });
+
+test("Sign in with Google ボタンを押すとログインに成功して /transactions に遷移する", async ({
+  page,
+}) => {
+  // E2E ビルドの GoogleSignInButton はスタブで、押下時に固定 credential を返す。
+  // MSW の `/api/v1/auth/google` ハンドラがモック JWT を返し、useGoogleLogin が
+  // /transactions に遷移する経路を検証する。
+  await page.goto("/login");
+  await expect(page.getByRole("heading", { name: "Expense Tracker" })).toBeVisible();
+
+  await page.getByRole("button", { name: /sign in with google/i }).click();
+
+  await expect(page).toHaveURL(/\/transactions$/);
+  await expect(page.getByRole("button", { name: /add transaction/i })).toBeVisible();
+});

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -70,29 +70,9 @@ export async function refetchQueries(page: Page): Promise<void> {
   }, HOOKS_NOT_EXPOSED);
 }
 
-async function mockGet(page: Page, path: string, payload: JsonBodyType): Promise<void> {
-  await waitForE2EHooks(page);
-  await page.evaluate(
-    ({ path, payload, errorMessage }) => {
-      const worker = window.__mswWorker;
-      const http = window.__mswHttp;
-      const HttpResponse = window.__mswHttpResponse;
-      if (!worker || !http || !HttpResponse) {
-        throw new Error(errorMessage);
-      }
-      worker.use(http.get(path, () => HttpResponse.json(payload)));
-    },
-    { path, payload, errorMessage: HOOKS_NOT_EXPOSED },
-  );
-}
-
 type HttpMethod = "get" | "post" | "put" | "delete";
 
-/**
- * 任意の HTTP メソッド・パス・ステータス・ボディの応答を `worker.use()` で差し替える。
- * 422 / 401 などの異常系シナリオで使う。
- */
-export async function mockApiError(
+async function installHandler(
   page: Page,
   method: HttpMethod,
   path: string,
@@ -114,20 +94,33 @@ export async function mockApiError(
   );
 }
 
+/**
+ * 422 / 401 など、特定エンドポイントを異常系応答に差し替えたいときに使う。
+ */
+export function mockApiError(
+  page: Page,
+  method: HttpMethod,
+  path: string,
+  status: number,
+  body: JsonBodyType,
+): Promise<void> {
+  return installHandler(page, method, path, status, body);
+}
+
 export function mockTransactionList(page: Page, items: TransactionResponse[]): Promise<void> {
-  return mockGet(page, "/api/v1/transactions", { items });
+  return installHandler(page, "get", "/api/v1/transactions", 200, { items });
 }
 
 export function mockCategoryAnalytics(
   page: Page,
   payload: CategoryAnalyticsResponse,
 ): Promise<void> {
-  return mockGet(page, "/api/v1/analytics/category", payload);
+  return installHandler(page, "get", "/api/v1/analytics/category", 200, payload);
 }
 
 export function mockNeedWantAnalytics(
   page: Page,
   payload: NeedWantAnalyticsResponse,
 ): Promise<void> {
-  return mockGet(page, "/api/v1/analytics/need-want", payload);
+  return installHandler(page, "get", "/api/v1/analytics/need-want", 200, payload);
 }

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -86,6 +86,34 @@ async function mockGet(page: Page, path: string, payload: JsonBodyType): Promise
   );
 }
 
+type HttpMethod = "get" | "post" | "put" | "delete";
+
+/**
+ * 任意の HTTP メソッド・パス・ステータス・ボディの応答を `worker.use()` で差し替える。
+ * 422 / 401 などの異常系シナリオで使う。
+ */
+export async function mockApiError(
+  page: Page,
+  method: HttpMethod,
+  path: string,
+  status: number,
+  body: JsonBodyType,
+): Promise<void> {
+  await waitForE2EHooks(page);
+  await page.evaluate(
+    ({ method, path, status, body, errorMessage }) => {
+      const worker = window.__mswWorker;
+      const http = window.__mswHttp;
+      const HttpResponse = window.__mswHttpResponse;
+      if (!worker || !http || !HttpResponse) {
+        throw new Error(errorMessage);
+      }
+      worker.use(http[method](path, () => HttpResponse.json(body, { status })));
+    },
+    { method, path, status, body, errorMessage: HOOKS_NOT_EXPOSED },
+  );
+}
+
 export function mockTransactionList(page: Page, items: TransactionResponse[]): Promise<void> {
   return mockGet(page, "/api/v1/transactions", { items });
 }

--- a/frontend/e2e/transactions.spec.ts
+++ b/frontend/e2e/transactions.spec.ts
@@ -89,6 +89,72 @@ test("既存の支出をクリックして編集すると一覧の表示が更�
   await page.screenshot({ path: "screenshots/transaction-edit-success.png" });
 });
 
+test("フィルタパネルでカテゴリ・Need/Want を指定するとリストが絞り込まれる", async ({ page }) => {
+  const lunch = {
+    id: 1,
+    date: "2026-05-07",
+    amount: "1200",
+    category_id: 1,
+    category_name: "Food",
+    need_want_type: "NEED" as const,
+    title: "ランチ",
+    created_at: "2026-05-07T12:00:00Z",
+    updated_at: "2026-05-07T12:00:00Z",
+  };
+  const train = {
+    id: 2,
+    date: "2026-05-07",
+    amount: "320",
+    category_id: 2,
+    category_name: "Transport",
+    need_want_type: "NEED" as const,
+    title: "電車",
+    created_at: "2026-05-07T09:00:00Z",
+    updated_at: "2026-05-07T09:00:00Z",
+  };
+  const movie = {
+    id: 3,
+    date: "2026-05-07",
+    amount: "1800",
+    category_id: 6,
+    category_name: "Entertainment",
+    need_want_type: "WANT" as const,
+    title: "映画",
+    created_at: "2026-05-07T19:00:00Z",
+    updated_at: "2026-05-07T19:00:00Z",
+  };
+
+  await seedAuthToken(page);
+  await page.goto("/transactions");
+  await expect(page.getByText(/No transactions yet/i)).toBeVisible();
+
+  await mockTransactionList(page, [lunch, train, movie]);
+  await refetchQueries(page);
+  await expect(page.getByText("ランチ")).toBeVisible();
+  await expect(page.getByText("電車")).toBeVisible();
+  await expect(page.getByText("映画")).toBeVisible();
+
+  await page.getByRole("button", { name: /^Filters/ }).click();
+
+  // カテゴリで Food を選ぶと、絞り込み後の API 応答（Food のみ）が返るよう差し替える。
+  await mockTransactionList(page, [lunch]);
+  await page.getByRole("button", { name: /^Categories/ }).click();
+  await page.getByRole("checkbox", { name: "Food" }).click();
+  await page.keyboard.press("Escape");
+
+  await expect(page.getByText("ランチ")).toBeVisible();
+  await expect(page.getByText("電車")).toBeHidden();
+  await expect(page.getByText("映画")).toBeHidden();
+  await expect(page.getByLabel("Active filter count")).toHaveText("1");
+
+  // Need/Want を WANT に切り替えると Food + WANT で 0 件になる想定。
+  await mockTransactionList(page, []);
+  await page.getByRole("radio", { name: "WANT" }).click();
+
+  await expect(page.getByText(/No transactions match your filters/i)).toBeVisible();
+  await expect(page.getByLabel("Active filter count")).toHaveText("2");
+});
+
 test("既存の支出を編集モーダルから削除すると一覧が空に戻る", async ({ page }) => {
   await seedAuthToken(page);
   await page.goto("/transactions");

--- a/frontend/e2e/transactions.spec.ts
+++ b/frontend/e2e/transactions.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-import { mockTransactionList, refetchQueries, seedAuthToken } from "./fixtures";
+import { mockApiError, mockTransactionList, refetchQueries, seedAuthToken } from "./fixtures";
 
 test("支出を新規登録するとモーダルが閉じて一覧に反映される", async ({ page }) => {
   await seedAuthToken(page);
@@ -197,4 +197,42 @@ test("既存の支出を編集モーダルから削除すると一覧が空に�
   await expect(page.getByText("映画")).toBeHidden();
 
   await page.screenshot({ path: "screenshots/transaction-delete-success.png" });
+});
+
+test("登録モーダルで 422 が返ると該当フィールドにインラインエラーが表示される", async ({
+  page,
+}) => {
+  await seedAuthToken(page);
+  await page.goto("/transactions");
+  await expect(page.getByText(/No transactions yet/i)).toBeVisible();
+
+  await page.getByRole("button", { name: "Add transaction" }).click();
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+
+  await dialog.getByLabel("Date").fill("2026-05-07");
+  await dialog.getByLabel("Amount").fill("1200");
+  await dialog.getByLabel("Category").selectOption({ label: "Food" });
+  await dialog.getByLabel("Title").fill("ランチ");
+
+  // BE のフィールドバリデーションが返る 422 を擬似的に返し、FE の useApiError が
+  // pointer (snake_case) → camelCase に変換してインラインエラーを描画することを検証する。
+  await mockApiError(page, "post", "/api/v1/transactions", 422, {
+    type: "/errors/validation-error",
+    title: "Your request is not valid.",
+    status: 422,
+    detail: "One or more fields have validation errors.",
+    errors: [
+      { pointer: "#/amount", detail: "amount must be positive" },
+      { pointer: "#/title", detail: "title must be 100 characters or fewer" },
+    ],
+  });
+
+  await dialog.getByRole("button", { name: "Save" }).click();
+
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByText("amount must be positive")).toBeVisible();
+  await expect(dialog.getByText("title must be 100 characters or fewer")).toBeVisible();
+  await expect(dialog.getByLabel("Amount")).toHaveAttribute("aria-invalid", "true");
+  await expect(dialog.getByLabel("Title")).toHaveAttribute("aria-invalid", "true");
 });

--- a/frontend/src/lib/queryClient.ts
+++ b/frontend/src/lib/queryClient.ts
@@ -1,4 +1,4 @@
-import { QueryClient } from "@tanstack/react-query";
+import { MutationCache, QueryCache, QueryClient } from "@tanstack/react-query";
 import { ApiException } from "./api/errors";
 
 /**
@@ -14,7 +14,23 @@ export function shouldRetryQuery(failureCount: number, error: Error): boolean {
   return failureCount < 3;
 }
 
+// ルーター生成後に main.tsx から登録する。queryClient は React 起動前に
+// import されるため、navigate を直接束縛できないことへの対処。
+let onUnauthorized: (() => void) | null = null;
+
+export function setOnUnauthorized(handler: () => void): void {
+  onUnauthorized = handler;
+}
+
+function redirectOnUnauthorized(error: unknown): void {
+  if (error instanceof ApiException && error.status === 401) {
+    onUnauthorized?.();
+  }
+}
+
 export const queryClient = new QueryClient({
+  queryCache: new QueryCache({ onError: redirectOnUnauthorized }),
+  mutationCache: new MutationCache({ onError: redirectOnUnauthorized }),
   defaultOptions: {
     queries: {
       retry: shouldRetryQuery,

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -27,7 +27,10 @@ const router = createBrowserRouter(routes);
 
 // AuthGuard は子の query エラーでは再評価されないため、401 はグローバルに拾って遷移させる。
 // トークンクリアは API クライアント側 (`lib/api/client.ts`) が責務を持つ。
+// 別アカウントで再ログインしたときに前ユーザーのキャッシュ（users/me 等）が
+// staleTime の間表示されないよう、遷移前にキャッシュも破棄する。
 setOnUnauthorized(() => {
+  queryClient.clear();
   void router.navigate("/login", { replace: true });
 });
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -25,8 +25,8 @@ declare global {
 
 const router = createBrowserRouter(routes);
 
-// 401 を受け取ったら API クライアント側でトークンをクリアした上で /login に遷移する。
-// AuthGuard は子の query エラーでは再評価されないため、グローバルに navigate する必要がある。
+// AuthGuard は子の query エラーでは再評価されないため、401 はグローバルに拾って遷移させる。
+// トークンクリアは API クライアント側 (`lib/api/client.ts`) が責務を持つ。
 setOnUnauthorized(() => {
   void router.navigate("/login", { replace: true });
 });

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -9,7 +9,7 @@ import { createBrowserRouter, RouterProvider } from "react-router";
 import { ToastProvider } from "./components/Toast";
 import "./index.css";
 import { setToken } from "./lib/auth";
-import { queryClient } from "./lib/queryClient";
+import { queryClient, setOnUnauthorized } from "./lib/queryClient";
 import { routes } from "./routes";
 
 declare global {
@@ -24,6 +24,12 @@ declare global {
 }
 
 const router = createBrowserRouter(routes);
+
+// 401 を受け取ったら API クライアント側でトークンをクリアした上で /login に遷移する。
+// AuthGuard は子の query エラーでは再評価されないため、グローバルに navigate する必要がある。
+setOnUnauthorized(() => {
+  void router.navigate("/login", { replace: true });
+});
 
 const root = document.getElementById("root");
 if (!root) {


### PR DESCRIPTION
## 概要

Issue #260 の「優先度: 中（重要なエッジ）」の 5 テスト（#7〜#11）を追加する。テスト #9（401 → ログイン画面リダイレクト）を成立させるため、QueryCache / MutationCache の `onError` で 401 を拾って `/login` に遷移するグローバルハンドラも併せて実装する。

## 変更内容

- E2E テスト追加
  - `transactions.spec.ts`: フィルタパネル（カテゴリ・Need/Want）で一覧が絞り込まれる（`#7`）
  - `transactions.spec.ts`: 登録モーダルで 422 が返ったら該当フィールドにインラインエラーが描画される（`#8`）
  - `auth.spec.ts`: 認証済みで 401 を受けると `/login` に遷移する（`#9`）
  - `auth.spec.ts`: 未認証で `/analytics` `/settings` に直アクセスすると `/login` に飛ぶ（`#10`）
  - `auth.spec.ts`: スタブ Google ボタン押下で `/transactions` に遷移する（`#11`）
- E2E フィクスチャ補強
  - 任意 HTTP メソッド/ステータス/ボディを `worker.use()` で差し替える `mockApiError` を追加
  - 既存の `mockTransactionList` / `mockCategoryAnalytics` / `mockNeedWantAnalytics` を共通の `installHandler` ベースに統合
- グローバル 401 ハンドラ
  - `queryClient.ts`: QueryCache / MutationCache の `onError` で `ApiException(401)` を検知し、登録済みコールバックを呼ぶ
  - `main.tsx`: ルーター生成後に `router.navigate("/login", { replace: true })` を `setOnUnauthorized` 経由で登録
  - 従来は `client.ts` がトークンをクリアするだけで、`AuthGuard` は子の query エラーでは再評価されないためリダイレクトされなかった

## 関連 Issue

Refs #260

## テスト

- `npm run check` 通過（Prettier + ESLint + tsc + Vitest 317 件 + Playwright 14 件 + Vite ビルド）
- 追加テスト 5 件はすべて Green
  - テスト `#9` は実装前に Red を確認 → グローバルハンドラ追加で Green に変化することを確認

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)