### PR TITLE
fix(frontend): 下部ナビがページ末尾コンテンツを覆う問題を修正

### DIFF
--- a/frontend/e2e/responsive.spec.ts
+++ b/frontend/e2e/responsive.spec.ts
@@ -35,9 +35,7 @@ test("PC 幅でも BottomNav が画面下部に表示される", async ({ page }
   await page.screenshot({ path: "screenshots/responsive-desktop-bottom-nav.png" });
 });
 
-// Issue #324: 短いビューポートで末尾コンテンツが BottomNav の裏に隠れる回帰を防ぐ。
-// ページコンテンツを内側スクロール領域に閉じ込め、ナビと座標的に重ならないこと
-// （ボタンをスクロールしてビューに入れた時点でナビ上端より上に収まること）を検証する。
+// Issue #324: 短いビューポートで BottomNav がページ末尾のコンテンツを覆う回帰を防ぐ。
 test("短いビューポートで Settings の Delete Account ボタンが BottomNav の裏に隠れない", async ({
   page,
 }) => {

--- a/frontend/e2e/responsive.spec.ts
+++ b/frontend/e2e/responsive.spec.ts
@@ -35,8 +35,9 @@ test("PC 幅でも BottomNav が画面下部に表示される", async ({ page }
   await page.screenshot({ path: "screenshots/responsive-desktop-bottom-nav.png" });
 });
 
-// Issue #324: ページの `min-h-screen` が AppLayout の `pb-16` を打ち消して、
-// 短いビューポートで末尾コンテンツが BottomNav の裏に隠れる回帰を防ぐ。
+// Issue #324: 短いビューポートで末尾コンテンツが BottomNav の裏に隠れる回帰を防ぐ。
+// ページコンテンツを内側スクロール領域に閉じ込め、ナビと座標的に重ならないこと
+// （ボタンをスクロールしてビューに入れた時点でナビ上端より上に収まること）を検証する。
 test("短いビューポートで Settings の Delete Account ボタンが BottomNav の裏に隠れない", async ({
   page,
 }) => {
@@ -46,11 +47,13 @@ test("短いビューポートで Settings の Delete Account ボタンが Botto
   await page.goto("/settings");
 
   const deleteButton = page.getByRole("button", { name: "Delete Account" });
+  await deleteButton.scrollIntoViewIfNeeded();
   await expect(deleteButton).toBeVisible();
 
   const buttonBox = await deleteButton.boundingBox();
   const navBox = await page.getByRole("navigation").boundingBox();
-  expect(buttonBox).not.toBeNull();
-  expect(navBox).not.toBeNull();
-  expect(buttonBox!.y + buttonBox!.height).toBeLessThanOrEqual(navBox!.y);
+  if (buttonBox === null || navBox === null) {
+    throw new Error("boundingBox returned null; element is not rendered or not visible");
+  }
+  expect(buttonBox.y + buttonBox.height).toBeLessThanOrEqual(navBox.y);
 });

--- a/frontend/e2e/responsive.spec.ts
+++ b/frontend/e2e/responsive.spec.ts
@@ -34,3 +34,23 @@ test("PC 幅でも BottomNav が画面下部に表示される", async ({ page }
 
   await page.screenshot({ path: "screenshots/responsive-desktop-bottom-nav.png" });
 });
+
+// Issue #324: ページの `min-h-screen` が AppLayout の `pb-16` を打ち消して、
+// 短いビューポートで末尾コンテンツが BottomNav の裏に隠れる回帰を防ぐ。
+test("短いビューポートで Settings の Delete Account ボタンが BottomNav の裏に隠れない", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 375, height: 493 });
+
+  await seedAuthToken(page);
+  await page.goto("/settings");
+
+  const deleteButton = page.getByRole("button", { name: "Delete Account" });
+  await expect(deleteButton).toBeVisible();
+
+  const buttonBox = await deleteButton.boundingBox();
+  const navBox = await page.getByRole("navigation").boundingBox();
+  expect(buttonBox).not.toBeNull();
+  expect(navBox).not.toBeNull();
+  expect(buttonBox!.y + buttonBox!.height).toBeLessThanOrEqual(navBox!.y);
+});

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -4,8 +4,10 @@ import { BottomNav } from "./BottomNav";
 
 export function AppLayout() {
   return (
-    <div className="pb-16">
-      <Outlet />
+    <div className="flex h-dvh flex-col">
+      <main className="flex-1 overflow-y-auto">
+        <Outlet />
+      </main>
       <BottomNav />
     </div>
   );

--- a/frontend/src/components/BottomNav.tsx
+++ b/frontend/src/components/BottomNav.tsx
@@ -9,7 +9,7 @@ const tabs = [
 
 export function BottomNav() {
   return (
-    <nav className="border-border bg-background fixed inset-x-0 bottom-0 border-t">
+    <nav className="border-border bg-background border-t">
       <ul className="flex justify-around">
         {tabs.map(({ to, label, icon: Icon }) => (
           <li key={to}>

--- a/frontend/src/features/analytics/components/AnalyticsPage.tsx
+++ b/frontend/src/features/analytics/components/AnalyticsPage.tsx
@@ -19,7 +19,7 @@ export default function AnalyticsPage() {
   const { data: needWantData } = useNeedWantAnalytics(period);
 
   return (
-    <div className="relative min-h-screen">
+    <div className="relative">
       <div className="border-border bg-background sticky top-0 z-10 flex flex-col gap-2 border-b px-4 py-3">
         <PeriodSelector value={periodValue} onChange={setPeriodValue} />
       </div>

--- a/frontend/src/features/settings/components/SettingsPage.tsx
+++ b/frontend/src/features/settings/components/SettingsPage.tsx
@@ -41,7 +41,7 @@ export default function SettingsPage() {
   };
 
   return (
-    <div className="min-h-screen px-4 py-4">
+    <div className="px-4 py-4">
       <h1 className="font-heading mb-4 text-xl font-semibold">Settings</h1>
 
       <section aria-label="Account" className="mb-4">

--- a/frontend/src/features/transactions/components/TransactionsPage.tsx
+++ b/frontend/src/features/transactions/components/TransactionsPage.tsx
@@ -50,7 +50,7 @@ export default function TransactionsPage() {
   const { data: categoriesData } = useCategories();
 
   return (
-    <div className="relative min-h-screen">
+    <div className="relative">
       <div className="border-border bg-background sticky top-0 z-10 flex flex-col gap-2 border-b px-4 py-3">
         <PeriodSelector value={periodValue} onChange={setPeriodValue} />
         <TransactionFilters


### PR DESCRIPTION
## 概要
短いビューポート（縦 ~493px）で `/settings` を開くと、固定配置の `BottomNav` が `Delete Account` ボタンに被さって操作不能になる問題を修正する。`AppLayout` を内側スクロール領域化し、ナビをコンテンツと座標的に分離した。

## 変更内容
- `AppLayout`: `flex h-dvh flex-col` + `<main className="flex-1 overflow-y-auto">` でメイン領域を内側スクロール化
- `BottomNav`: `fixed` を外し flex の末尾要素としてフローに参加させる（高さ 57px のまま）
- `SettingsPage` / `TransactionsPage` / `AnalyticsPage` から `min-h-screen` を削除（親が高さを確保するため不要）
- E2E: 短ビューポート (375×493) で `Delete Account` ボタンをスクロールしてもナビと重ならないことを検証するテストを追加

## 関連 Issue
Closes #324

## スクリーンショット
修正前 / 修正後（viewport 375×493、`/settings`）

- `frontend/screenshots/issue-324-repro-settings-375x493.png`（修正前: Delete Account がナビに隠れる）
<img width="375" height="493" alt="issue-324-repro-settings-375x493" src="https://github.com/user-attachments/assets/382afa08-3ff5-4a1b-9c46-3448cd6f900e" />

- `frontend/screenshots/issue-324-fixed-settings-375x493.png`（修正後: 完全に表示）
<img width="375" height="493" alt="issue-324-fixed-settings-375x493" src="https://github.com/user-attachments/assets/ebbded50-3e2e-460d-9a1b-61f4eb02c641" />


## テスト
- [x] 単体テスト: 317/317 passed
- [x] E2E: 24/24 passed（新規 1 件含む）
- [x] `npm run check` 全 Green
- [x] Playwright MCP で `/settings`, `/transactions`, `/analytics` を 375×493 で目視確認（sticky ヘッダー・FAB の挙動も維持されることを確認）

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)