### PR TITLE
fix(frontend): ルート遷移時に内側スクロール位置を先頭にリセット

### DIFF
--- a/frontend/e2e/navigation.spec.ts
+++ b/frontend/e2e/navigation.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-import { seedAuthToken } from "./fixtures";
+import { mockTransactionList, refetchQueries, seedAuthToken } from "./fixtures";
 
 test("ボトムナビで Transactions ↔ Analytics ↔ Settings を行き来できる", async ({ page }) => {
   await seedAuthToken(page);
@@ -22,4 +22,40 @@ test("ボトムナビで Transactions ↔ Analytics ↔ Settings を行き来で
   await expect(page.getByRole("button", { name: /add transaction/i })).toBeVisible();
 
   await page.screenshot({ path: "screenshots/bottom-nav-transactions.png" });
+});
+
+test("ルート遷移時に内側スクロール位置が先頭に戻る", async ({ page }) => {
+  await seedAuthToken(page);
+
+  const longList = Array.from({ length: 60 }, (_, i) => ({
+    id: i + 1,
+    date: "2026-05-01",
+    amount: "1000",
+    category_id: 11,
+    category_name: "Uncategorized",
+    need_want_type: "UNSET" as const,
+    title: `Item ${String(i + 1)}`,
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-01T00:00:00Z",
+  }));
+
+  await page.goto("/transactions");
+  await mockTransactionList(page, longList);
+  await refetchQueries(page);
+
+  await expect(page.getByRole("button", { name: /^Item 1\b/ })).toBeVisible();
+
+  const main = page.getByRole("main");
+  await main.evaluate((el) => {
+    el.scrollTo({ top: 1000 });
+  });
+  const scrolledTop = await main.evaluate((el) => el.scrollTop);
+  expect(scrolledTop).toBeGreaterThan(0);
+
+  await page.getByRole("navigation").getByRole("link", { name: "Analytics" }).click();
+  await expect(page).toHaveURL(/\/analytics$/);
+  await expect(page.getByRole("heading", { name: "Category Breakdown" })).toBeVisible();
+
+  const afterNavTop = await main.evaluate((el) => el.scrollTop);
+  expect(afterNavTop).toBe(0);
 });

--- a/frontend/src/components/AppLayout.test.tsx
+++ b/frontend/src/components/AppLayout.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import { createMemoryRouter, RouterProvider } from "react-router";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { AppLayout } from "./AppLayout";
 
@@ -22,6 +22,10 @@ function renderWithRouter(initialEntry: string) {
 }
 
 describe("AppLayout", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("renders child route content", async () => {
     renderWithRouter("/transactions");
 
@@ -34,5 +38,20 @@ describe("AppLayout", () => {
     expect(screen.getByRole("link", { name: /transactions/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /analytics/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /settings/i })).toBeInTheDocument();
+  });
+
+  it("scrolls main to top on route change", async () => {
+    const scrollToSpy = vi.spyOn(Element.prototype, "scrollTo");
+    const router = renderWithRouter("/transactions");
+    await screen.findByRole("heading", { name: "Transactions" });
+    scrollToSpy.mockClear();
+
+    await act(async () => {
+      await router.navigate("/analytics");
+    });
+
+    expect(scrollToSpy).toHaveBeenCalledWith({ top: 0, behavior: "instant" });
+    const mainElement = screen.getByRole("main");
+    expect(scrollToSpy.mock.instances).toContain(mainElement);
   });
 });

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -1,11 +1,21 @@
-import { Outlet } from "react-router";
+import { useLayoutEffect, useRef } from "react";
+import { Outlet, useLocation } from "react-router";
 
 import { BottomNav } from "./BottomNav";
 
 export function AppLayout() {
+  const mainRef = useRef<HTMLElement>(null);
+  const { pathname } = useLocation();
+
+  // React Router 7 の <ScrollRestoration /> は document scroller 専用のため、内側スクロール
+  // コンテナは手動でリセットする。useLayoutEffect は描画前に走らせて初期位置のチラつきを防ぐ。
+  useLayoutEffect(() => {
+    mainRef.current?.scrollTo({ top: 0, behavior: "instant" });
+  }, [pathname]);
+
   return (
     <div className="flex h-dvh flex-col">
-      <main className="flex-1 overflow-y-auto">
+      <main ref={mainRef} className="flex-1 overflow-y-auto">
         <Outlet />
       </main>
       <BottomNav />

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -7,6 +7,8 @@ import { server } from "./mocks/server";
 Element.prototype.hasPointerCapture = () => false;
 Element.prototype.setPointerCapture = () => {};
 Element.prototype.releasePointerCapture = () => {};
+// jsdom は Element#scrollTo を実装しないため no-op で埋める
+Element.prototype.scrollTo = () => {};
 
 beforeAll(() => {
   server.listen({ onUnhandledRequest: "error" });


### PR DESCRIPTION
## 概要

`AppLayout` の `<main>` が内側スクロールコンテナになったことで、React Router 7 のルート遷移時にスクロール位置が次ページに引き継がれる副作用を修正する。

## 変更内容

- `AppLayout` で `useLocation` の `pathname` 変化を検知し、`<main>` の `scrollTop` を 0 にリセット
  - `<ScrollRestoration />` は document scroller 専用で、内側スクロールコンテナには対応できないため自前で実装（React Router 7 公式の推奨パターン）
  - `useLayoutEffect` を採用し、旧位置で 1 フレーム描画されるチラつきを防止
  - `behavior: "instant"` を明示し、将来 `scroll-behavior: smooth` が指定された場合の意図しないアニメーションを回避
- 単体テストで `Element.prototype.scrollTo` をスパイし、遷移時に `{ top: 0, behavior: "instant" }` が呼ばれることを検証
- E2E テストで「下までスクロール → 別ルートに遷移 → scrollTop が 0」のシナリオを追加
- jsdom 用に `Element#scrollTo` を no-op で polyfill（`src/test/setup.ts`）

## 関連 Issue

Closes #343

## スクリーンショット

- `frontend/screenshots/scroll-before-nav-transactions.png` — Transactions を下までスクロールした状態（Item 15〜20 表示）
<img width="375" height="493" alt="scroll-before-nav-transactions" src="https://github.com/user-attachments/assets/9945cb23-4f52-4043-80c6-a7d568eca30a" />

- `frontend/screenshots/scroll-after-nav-analytics.png` — Analytics 遷移後にスクロール位置が先頭（"May 2026" カレンダーヘッダから表示）
<img width="375" height="493" alt="scroll-after-nav-analytics" src="https://github.com/user-attachments/assets/e9048ab3-301c-4a7c-9bee-8a1c2e1d94bc" />

## テスト

- [x] `npm run check` 全パス（Prettier / ESLint / tsc / Vitest 318 件 / Playwright 25 件 / Vite build）
- [x] 追加した E2E シナリオ「ルート遷移時に内側スクロール位置が先頭に戻る」がパス
- [x] Playwright MCP で Transactions → Analytics 遷移時のスクロールリセットを目視確認

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)